### PR TITLE
Revolutionary Repo.status() and path handling

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
       PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda35
       DATALAD_REPO_VERSION: 6
+      DATALAD_LOG_LEVEL: debug
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"

--- a/datalad_revolution/annexrepo.py
+++ b/datalad_revolution/annexrepo.py
@@ -4,7 +4,10 @@ from collections import OrderedDict
 import logging
 from six import iteritems
 
-from pathlib import PurePosixPath
+from pathlib import (
+    Path,
+    PurePosixPath,
+)
 
 from datalad.support.annexrepo import AnnexRepo
 
@@ -38,8 +41,11 @@ class RevolutionAnnexRepo(AnnexRepo, RevolutionGitRepo):
             # what scheme is used in a given annex
             r['has_content'] = False
             for testpath in (
-                    objectstore.joinpath(r['hashdirmixed'], r['key']),
-                    objectstore.joinpath(r['hashdirlower'], r['key'])):
+                    # ATM git-annex reports hashdir in native path
+                    # conventions and the actual file path `f` in
+                    # POSIX, weired...
+                    objectstore.joinpath(Path(r['hashdirmixed']), r['key']),
+                    objectstore.joinpath(Path(r['hashdirlower']), r['key'])):
                 if testpath.exists():
                     r.pop('hashdirlower', None)
                     r.pop('hashdirmixed', None)

--- a/datalad_revolution/annexrepo.py
+++ b/datalad_revolution/annexrepo.py
@@ -36,12 +36,18 @@ class RevolutionAnnexRepo(AnnexRepo, RevolutionGitRepo):
             # TODO optimize order based on some check that reveals
             # what scheme is used in a given annex
             r['has_content'] = False
+            key = r['key']
             for testpath in (
                     # ATM git-annex reports hashdir in native path
                     # conventions and the actual file path `f` in
                     # POSIX, weired...
-                    objectstore.joinpath(ut.Path(r['hashdirmixed']), r['key']),
-                    objectstore.joinpath(ut.Path(r['hashdirlower']), r['key'])):
+                    # we need to test for the actual key file, not
+                    # just the containing dir, as on windows the latter
+                    # may not always get cleaned up on `drop`
+                    objectstore.joinpath(
+                        ut.Path(r['hashdirmixed']), key, key),
+                    objectstore.joinpath(
+                        ut.Path(r['hashdirlower']), key, key)):
                 if testpath.exists():
                     r.pop('hashdirlower', None)
                     r.pop('hashdirmixed', None)

--- a/datalad_revolution/annexrepo.py
+++ b/datalad_revolution/annexrepo.py
@@ -1,6 +1,9 @@
 __docformat__ = 'restructuredtext'
 
+from collections import OrderedDict
 import logging
+import os.path as op
+from six import iteritems
 
 from datalad.support.annexrepo import AnnexRepo
 
@@ -13,14 +16,130 @@ from datalad_revolution.utils import nothere
 lgr = logging.getLogger('datalad_revolution.annexrepo')
 
 obsolete_methods = (
-    'get_status',
-    'untracked_files',
+    # next two are only needed by 'ok_clean_git'
+    # 'untracked_files',
+    # 'get_status',
     'is_dirty',
 )
 
 
 class RevolutionAnnexRepo(AnnexRepo, RevolutionGitRepo):
-    pass
+    def _mark_content_availability(self, info):
+        objectstore = op.join(
+            self.path, RevolutionGitRepo.get_git_dir(self), 'annex', 'objects')
+        for f, r in iteritems(info):
+            if 'key' not in r:
+                # not annexed
+                continue
+            # test hashdirmixed first, as it is used in non-bare repos
+            # which be a more frequent target
+            # TODO optimize order based on some check that reveals
+            # what scheme is used in a given annex
+            r['has_content'] = False
+            for testpath in (
+                    op.join(objectstore, r['hashdirmixed'], r['key']),
+                    op.join(objectstore, r['hashdirlower'], r['key'])):
+                if op.exists(testpath):
+                    r.pop('hashdirlower', None)
+                    r.pop('hashdirmixed', None)
+                    r['objloc'] = testpath
+                    r['has_content'] = True
+                    break
+
+    def get_content_annexinfo(
+            self, paths=None, init='git', ref=None, eval_availability=False, **kwargs):
+        """
+        Calling without any options given will always give the fastest
+        performance.
+
+        Parameters
+        ----------
+        paths : list
+          Specific paths to query info for. In none are given, info is
+          reported for all content.
+        init : 'git' or dict-like or None
+          If set to 'git' annex content info will ammend the output of
+          GitRepo.get_content_info(), otherwise the dict-like object
+          supplied will receive this information and the present keys will
+          limit the report of annex properties. Alternatively, if `None`
+          is given, no initialization is done, and no limit is in effect.
+        ref : gitref or None
+          If not None, annex content info for this Git reference will be
+          produced, otherwise for the content of the present worktree.
+        eval_availability : bool
+          If this flag is given, evaluate whether the content of any annex'ed
+          file is present in the local annex.
+        **kwargs :
+          Additional arguments for GitRepo.get_content_info(), if `init` is
+          set to 'git'.
+
+        Returns
+        -------
+        dict
+          Each content item has an entry under its relative path within
+          the repository. Each value is a dictionary with properties:
+
+          `type`
+            Can be 'file', 'symlink', 'dataset', 'directory'
+          `revision`
+            SHASUM is last commit affecting the item, or None, if not
+            tracked.
+          `key`
+            Annex key of a file (if an annex'ed file)
+          `bytesize`
+            Size of an annexed file in bytes.
+          `has_content`
+            Bool whether a content object for this key exists in the local annex (with
+            `eval_availability`)
+          `objloc`
+            Absolute path of the content object in the local annex, if one is available
+            (with `eval_availability`)
+        """
+        if init is None:
+            info = OrderedDict()
+        elif init == 'git':
+            info = super(AnnexRepo, self).get_content_info(
+                paths=paths, **kwargs)
+        else:
+            info = init
+        if ref:
+            cmd = 'findref'
+            opts = [ref]
+        else:
+            cmd = 'find'
+            # TODO maybe inform by `path`?
+            opts = ['--include', '*']
+        for j in self._run_annex_command_json(cmd, opts=opts):
+            path = j['file']
+            if init is not None and path not in info:
+                # ignore anything that Git hasn't reported on
+                # TODO figure out when it is more efficient to query
+                # a particular set of paths, instead of all of them
+                # and just throwing away the results
+                continue
+            rec = info.get(path, {})
+            rec.update({k: j[k] for k in j if k != 'file'})
+            info[path] = rec
+            # TODO make annex availability checks optional and move in here
+            if not eval_availability:
+                # not desired, or not annexed
+                continue
+            self._mark_content_availability(info)
+        return info
+
+    def annexstatus(self, paths=None, untracked='all'):
+        info = self.get_content_annexinfo(
+            eval_availability=False,
+            init=self.get_content_annexinfo(
+                paths=paths,
+                ref='HEAD',
+                eval_availability=False))
+        self._mark_content_availability(info)
+        for f, r in iteritems(self.status(paths=paths)):
+            info[f].update(r)
+
+        return info
+
 
 
 # remove deprecated methods from API

--- a/datalad_revolution/annexrepo.py
+++ b/datalad_revolution/annexrepo.py
@@ -13,7 +13,7 @@ from datalad_revolution.gitrepo import (
 )
 from datalad_revolution.utils import nothere
 
-lgr = logging.getLogger('datalad_revolution.annexrepo')
+lgr = logging.getLogger('datalad.revolution.annexrepo')
 
 obsolete_methods = (
     # next two are only needed by 'ok_clean_git'

--- a/datalad_revolution/annexrepo.py
+++ b/datalad_revolution/annexrepo.py
@@ -4,10 +4,7 @@ from collections import OrderedDict
 import logging
 from six import iteritems
 
-from pathlib import (
-    Path,
-    PurePosixPath,
-)
+import datalad_revolution.utils as ut
 
 from datalad.support.annexrepo import AnnexRepo
 
@@ -15,7 +12,6 @@ from datalad_revolution.gitrepo import (
     RevolutionGitRepo,
     obsolete_methods as gitrepo_obsolete_methods,
 )
-from datalad_revolution.utils import nothere
 
 lgr = logging.getLogger('datalad.revolution.annexrepo')
 
@@ -44,8 +40,8 @@ class RevolutionAnnexRepo(AnnexRepo, RevolutionGitRepo):
                     # ATM git-annex reports hashdir in native path
                     # conventions and the actual file path `f` in
                     # POSIX, weired...
-                    objectstore.joinpath(Path(r['hashdirmixed']), r['key']),
-                    objectstore.joinpath(Path(r['hashdirlower']), r['key'])):
+                    objectstore.joinpath(ut.Path(r['hashdirmixed']), r['key']),
+                    objectstore.joinpath(ut.Path(r['hashdirlower']), r['key'])):
                 if testpath.exists():
                     r.pop('hashdirlower', None)
                     r.pop('hashdirmixed', None)
@@ -118,7 +114,7 @@ class RevolutionAnnexRepo(AnnexRepo, RevolutionGitRepo):
             # TODO maybe inform by `path`?
             opts = ['--include', '*']
         for j in self._run_annex_command_json(cmd, opts=opts):
-            path = self.pathobj.joinpath(PurePosixPath(j['file']))
+            path = self.pathobj.joinpath(ut.PurePosixPath(j['file']))
             if init is not None and path not in info:
                 # ignore anything that Git hasn't reported on
                 # TODO figure out when it is more efficient to query
@@ -152,4 +148,4 @@ class RevolutionAnnexRepo(AnnexRepo, RevolutionGitRepo):
 # remove deprecated methods from API
 for m in obsolete_methods + gitrepo_obsolete_methods:
     if hasattr(RevolutionAnnexRepo, m):
-        setattr(RevolutionAnnexRepo, m, nothere)
+        setattr(RevolutionAnnexRepo, m, ut.nothere)

--- a/datalad_revolution/dataset.py
+++ b/datalad_revolution/dataset.py
@@ -15,7 +15,7 @@ from datalad_revolution.gitrepo import RevolutionGitRepo
 from datalad_revolution.annexrepo import RevolutionAnnexRepo
 from datalad_revolution.utils import nothere
 
-lgr = logging.getLogger('datalad_revolution.dataset')
+lgr = logging.getLogger('datalad.revolution.dataset')
 
 
 class RevolutionDataset(Dataset):

--- a/datalad_revolution/dataset.py
+++ b/datalad_revolution/dataset.py
@@ -2,6 +2,7 @@ __docformat__ = 'restructuredtext'
 
 from six import string_types
 import logging
+from pathlib import Path
 
 from datalad.distribution.dataset import Dataset
 from datalad.support.constraints import Constraint
@@ -19,6 +20,13 @@ lgr = logging.getLogger('datalad.revolution.dataset')
 
 
 class RevolutionDataset(Dataset):
+    @property
+    def pathobj(self):
+        """pathobj for the dataset"""
+        # XXX this relies on the assumption that self._path as managed
+        # by the base class is always a native path
+        return Path(self._path)
+
     @property
     def repo(self):
         """Get an instance of the version control system/repo for this dataset,

--- a/datalad_revolution/dataset.py
+++ b/datalad_revolution/dataset.py
@@ -2,7 +2,7 @@ __docformat__ = 'restructuredtext'
 
 from six import string_types
 import logging
-from pathlib import Path
+import datalad_revolution.utils as ut
 
 from datalad.distribution.dataset import Dataset
 from datalad.support.constraints import Constraint
@@ -14,7 +14,6 @@ from datalad.support.gitrepo import (
 
 from datalad_revolution.gitrepo import RevolutionGitRepo
 from datalad_revolution.annexrepo import RevolutionAnnexRepo
-from datalad_revolution.utils import nothere
 
 lgr = logging.getLogger('datalad.revolution.dataset')
 
@@ -25,7 +24,7 @@ class RevolutionDataset(Dataset):
         """pathobj for the dataset"""
         # XXX this relies on the assumption that self._path as managed
         # by the base class is always a native path
-        return Path(self._path)
+        return ut.Path(self._path)
 
     @property
     def repo(self):
@@ -73,7 +72,7 @@ class RevolutionDataset(Dataset):
 
 
 # remove deprecated method from API
-setattr(RevolutionDataset, 'get_subdatasets', nothere)
+setattr(RevolutionDataset, 'get_subdatasets', ut.nothere)
 
 
 # Note: Cannot be defined within constraints.py, since then dataset.py needs to

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -12,7 +12,7 @@ from datalad.support.gitrepo import GitRepo
 
 from datalad_revolution.utils import nothere
 
-lgr = logging.getLogger('datalad_revolution.gitrepo')
+lgr = logging.getLogger('datalad.revolution.gitrepo')
 
 obsolete_methods = (
     'dirty',

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -107,6 +107,13 @@ class RevolutionGitRepo(GitRepo):
             if not props:
                 # not known to Git
                 path = line.strip(op.sep)
+                if untracked == 'normal' and path.endswith('/'):
+                    # Git reports untracked dirs with a trailing slash
+                    # in this mode (even on windows)
+                    # kill this annotation and record a type property
+                    # instead
+                    inf['type'] = 'directory'
+                    path = path[:-1]
                 inf['gitshasum'] = None
             else:
                 path = props.group(4).strip(op.sep)

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -1,6 +1,12 @@
 __docformat__ = 'restructuredtext'
 
+from collections import OrderedDict
 import logging
+import os
+import os.path as op
+import re
+from six import iteritems
+import stat
 
 from datalad.support.gitrepo import GitRepo
 
@@ -15,7 +21,191 @@ obsolete_methods = (
 
 
 class RevolutionGitRepo(GitRepo):
-    pass
+    def get_content_info(self, paths=None, ref=None, stat_wt=False,
+                         untracked='all'):
+        """Get identifier and type information from repository content.
+
+        This is simplified front-end for `git ls-files/tree`.
+
+        Parameters
+        ----------
+        paths : list
+          Specific paths to query info for. In none are given, info is
+          reported for all content.
+        ref : gitref or None
+          If given, content information is retrieved for this Git reference
+          (via ls-tree), otherwise content information is produced for the
+          present work tree (via ls-files).
+        stat_wt : bool
+          If given, reports the result of `os.lstat()` as `stat_wt` property
+          for the work tree content.
+        untracked : {'no', 'normal', 'all'}
+          If and how untracked content is reported when no `ref` was given:
+          'no': no untracked files are reported; 'normal': untracked files
+          and entire untracked directories are reported as such; 'all': report
+          individual files even in fully untracked directories.
+
+        Returns
+        -------
+        dict
+          Each content item has an entry under its relative path within
+          the repository. Each value is a dictionary with properties:
+
+          `type`
+            Can be 'file', 'symlink', 'dataset', 'directory'
+          `gitshasum`
+            SHASUM of the item as tracked by Git, or None, if not
+            tracked. This could be different from the SHASUM of the file
+            in the worktree, if it was modified.
+        """
+        # TODO limit by file type to replace code in subdatasets command
+        info = OrderedDict()
+
+        mode_type_map = {
+            '100644': 'file',
+            '100755': 'file',
+            '120000': 'symlink',
+            '160000': 'dataset',
+        }
+
+        # this will not work in direct mode, but everything else should be
+        # just fine
+        if not ref:
+            cmd = ['git', 'ls-files', '--stage', '-z', '-d', '-m']
+            # untracked report mode, using labels from `git diff` option style
+            if untracked == 'all':
+                cmd.append('-o')
+            elif untracked == 'normal':
+                cmd += ['-o', '--directory']
+            elif untracked == 'no':
+                pass
+            else:
+                raise ValueError(
+                    'unknown value for `untracked`: %s', untracked)
+        else:
+            cmd = ['git', 'ls-tree', ref, '-z', '-r', '--full-tree']
+        # works for both modes
+        props_re = re.compile(r'([0-9]+) (.*) (.*)\t(.*)$')
+
+        stdout, stderr = self._git_custom_command(
+            paths if paths else [],
+            cmd,
+            log_stderr=True,
+            log_stdout=True,
+            # not sure why exactly, but log_online has to be false!
+            log_online=False,
+            expect_stderr=False,
+            shell=False,
+            # we don't want it to scream on stdout
+            expect_fail=True)
+
+        for line in stdout.split('\0'):
+            if not line:
+                continue
+            inf = {}
+            props = props_re.match(line)
+            if not props:
+                # not known to Git
+                path = line.strip(op.sep)
+                inf['gitshasum'] = None
+            else:
+                path = props.group(4).strip(op.sep)
+                inf['gitshasum'] = props.group(2 if not ref else 3)
+                inf['type'] = mode_type_map.get(
+                    props.group(1), props.group(1))
+            abspath_ = op.join(self.path, path)
+            if stat_wt:
+                if not op.lexists(abspath_):
+                    inf['stat_wt'] = None
+                else:
+                    s = os.lstat(abspath_)
+                    inf['stat_wt'] = s
+                    if 'type' not in inf:
+                        s = s.st_mode
+                        if stat.S_ISDIR(s):
+                            inf['type'] = 'directory'
+                        elif stat.S_ISREG(s):
+                            inf['type'] = 'file'
+                        elif stat.S_ISLNK(s):
+                            inf['type'] = 'symlink'
+
+            info[path] = inf
+        return info
+
+    def status(self, paths=None, untracked='all'):
+        """Simplified `git status` equivalent.
+
+        Performs a comparison of a get_content_info(stat_wt=True) with a
+        get_content_info(ref='HEAD').
+
+        Importantly, this function will not detect modified subdatasets.
+        This would require recursion into present subdatasets and query
+        their status. This is left to higher-level commands.
+
+        Parameters
+        ----------
+        untracked : {'no', 'normal', 'all'}
+          If and how untracked content is reported when no `ref` was given:
+          'no': no untracked files are reported; 'normal': untracked files
+          and entire untracked directories are reported as such; 'all': report
+          individual files even in fully untracked directories.
+
+        Returns
+        -------
+        dict
+          Each content item has an entry under its relative path within
+          the repository. Each value is a dictionary with properties:
+
+          `type`
+            Can be 'file', 'symlink', 'dataset', 'directory'
+          `state`
+            Can be 'added', 'untracked', 'clean', 'deleted', 'modified'.
+        """
+        # TODO report more info from get_content_info() calls in return
+        # value, those are cheap and possibly useful to a consumer
+        status = OrderedDict()
+        # we need three calls to git
+        # 1. everything we know about the worktree, including os.stat
+        # for each file
+        wt = self.get_content_info(
+            paths=paths, ref=None, stat_wt=True, untracked=untracked)
+        # 2. the last committed state
+        head = self.get_content_info(paths=paths, ref='HEAD', stat_wt=False)
+        # 3. we want Git to tell us what it considers modified and avoid
+        # reimplementing logic ourselves
+        modified = set(
+            p for p in self._git_custom_command(
+                paths, ['git', 'ls-files', '-z', '-m'])[0].split('\0')
+            if p)
+
+        for f, wt_r in iteritems(wt):
+            if f not in head:
+                # this is new, or rather not known to the previous state
+                status[f] = dict(
+                    state='added' if wt_r['gitshasum'] else 'untracked',
+                    type=wt_r['type'],
+                )
+            elif wt_r['gitshasum'] == head[f]['gitshasum'] and f not in modified:
+                # no change in git record, and no change on disk
+                status[f] = dict(
+                    state='clean' if wt_r['stat_wt'] else 'deleted',
+                    type=wt_r['type'],
+                )
+            else:
+                # change in git record, or on disk
+                status[f] = dict(
+                    # TODO is 'modified' enough, should be report typechange?
+                    # often this will be a pointless detail, though...
+                    # TODO we could have a new file that is already staged
+                    # but had subsequent modifications done to it that are
+                    # unstaged. Such file would presently show up as 'added'
+                    # ATM I think this is OK, but worth stating...
+                    state='modified' if wt_r['stat_wt'] else 'deleted',
+                    # TODO record before and after state for diff-like use cases
+                    type=wt_r['type'],
+                )
+
+        return status
 
 
 # remove deprecated methods from API

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -6,14 +6,8 @@ import logging
 import re
 from six import iteritems
 
-from pathlib import (
-    Path,
-    PurePosixPath,
-)
-
+import datalad_revolution.utils as ut
 from datalad.support.gitrepo import GitRepo
-
-from datalad_revolution.utils import nothere
 
 lgr = logging.getLogger('datalad.revolution.gitrepo')
 
@@ -30,7 +24,7 @@ class RevolutionGitRepo(GitRepo):
         # native path object to the instance
         # XXX this relies on the assumption that self.path as managed
         # by the base class is always a native path
-        self.pathobj = Path(self.path)
+        self.pathobj = ut.Path(self.path)
 
     def get_content_info(self, paths=None, ref=None, untracked='all'):
         """Get identifier and type information from repository content.
@@ -113,11 +107,11 @@ class RevolutionGitRepo(GitRepo):
             props = props_re.match(line)
             if not props:
                 # not known to Git, but Git always reports POSIX
-                path = PurePosixPath(line)
+                path = ut.PurePosixPath(line)
                 inf['gitshasum'] = None
             else:
                 # again Git reports always in POSIX
-                path = PurePosixPath(props.group(4))
+                path = ut.PurePosixPath(props.group(4))
                 inf['gitshasum'] = props.group(2 if not ref else 3)
                 inf['type'] = mode_type_map.get(
                     props.group(1), props.group(1))
@@ -176,7 +170,7 @@ class RevolutionGitRepo(GitRepo):
         # 3. we want Git to tell us what it considers modified and avoid
         # reimplementing logic ourselves
         modified = set(
-            self.pathobj.joinpath(PurePosixPath(p))
+            self.pathobj.joinpath(ut.PurePosixPath(p))
             for p in self._git_custom_command(
                 paths, ['git', 'ls-files', '-z', '-m'])[0].split('\0')
             if p)
@@ -222,4 +216,4 @@ class RevolutionGitRepo(GitRepo):
 # remove deprecated methods from API
 for m in obsolete_methods:
     if hasattr(RevolutionGitRepo, m):
-        setattr(RevolutionGitRepo, m, nothere)
+        setattr(RevolutionGitRepo, m, ut.nothere)

--- a/datalad_revolution/revcmd.py
+++ b/datalad_revolution/revcmd.py
@@ -16,6 +16,7 @@ from datalad_revolution.dataset import (
     RevolutionDataset,
 )
 
+
 # decoration auto-generates standard help
 @build_doc
 # all commands must be derived from Interface

--- a/datalad_revolution/tests/test_fileinfo.py
+++ b/datalad_revolution/tests/test_fileinfo.py
@@ -25,13 +25,14 @@ from datalad.api import (
 )
 
 from datalad_revolution.dataset import RevolutionDataset
-from datalad_revolution.gitrepo import RevolutionGitRepo
+from datalad_revolution.dataset import RevolutionDataset as Dataset
+from datalad_revolution.gitrepo import RevolutionGitRepo as GitRepo
 from datalad_revolution.tests.utils import assert_repo_status
 
 
 def _get_convoluted_situation(path):
     # TODO remove when `create` is RF to return the new Dataset
-    ds = RevolutionDataset(RevolutionDataset(path).create(force=True).path)
+    ds = RevolutionDataset(Dataset(path).create(force=True).path)
     # base content, all into the annex
     create_tree(
         ds.path,
@@ -122,7 +123,7 @@ def _get_convoluted_situation(path):
 
 @with_tempfile
 def test_get_content_info(path):
-    repo = RevolutionGitRepo(path)
+    repo = GitRepo(path)
     assert_equal(repo.get_content_info(), {})
 
     ds = _get_convoluted_situation(path)
@@ -230,7 +231,7 @@ def test_get_content_info(path):
 @with_tempfile
 def test_compare_content_info(path):
     # TODO remove when `create` is RF to return the new Dataset
-    ds = RevolutionDataset(RevolutionDataset(path).create().path)
+    ds = RevolutionDataset(Dataset(path).create().path)
     assert_repo_status(path)
 
     # for a clean repo HEAD and worktree query should yield identical results

--- a/datalad_revolution/tests/test_fileinfo.py
+++ b/datalad_revolution/tests/test_fileinfo.py
@@ -232,6 +232,12 @@ def test_get_content_info(path):
                     assert_not_in('key', annexstatus[p])
                     continue
                 assert_in('key', annexstatus[p])
+                # dear future,
+                # if the next one fails, git-annex might have changed the
+                # nature of the path that are being reported by
+                # `annex find --json`
+                # when this was written `hashir*` was a native path, but
+                # `file` was a POSIX path
                 assert_equal(annexstatus[p]['has_content'], 'dropped' not in s)
 
 

--- a/datalad_revolution/tests/test_fileinfo.py
+++ b/datalad_revolution/tests/test_fileinfo.py
@@ -18,7 +18,6 @@ from datalad.tests.utils import (
     assert_dict_equal,
     assert_in,
     assert_not_in,
-    ok_clean_git,
 )
 
 from datalad.api import (
@@ -27,6 +26,7 @@ from datalad.api import (
 
 from datalad_revolution.dataset import RevolutionDataset
 from datalad_revolution.gitrepo import RevolutionGitRepo
+from datalad_revolution.tests.utils import assert_repo_status
 
 
 def _get_convoluted_situation(path):
@@ -76,7 +76,7 @@ def _get_convoluted_situation(path):
         'subds_unavailable_clean',
         op.join('subdir', 'subds_unavailable_clean')],
         check=False)
-    ok_clean_git(ds.path)
+    assert_repo_status(ds.path)
     # staged subds, and files
     create(op.join(ds.path, 'subds_added'))
     ds.repo.add_submodule('subds_added')
@@ -231,7 +231,7 @@ def test_get_content_info(path):
 def test_compare_content_info(path):
     # TODO remove when `create` is RF to return the new Dataset
     ds = RevolutionDataset(RevolutionDataset(path).create().path)
-    ok_clean_git(path)
+    assert_repo_status(path)
 
     # for a clean repo HEAD and worktree query should yield identical results
     wt = ds.repo.get_content_info(ref=None)

--- a/datalad_revolution/tests/test_fileinfo.py
+++ b/datalad_revolution/tests/test_fileinfo.py
@@ -1,0 +1,238 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test file info getters"""
+
+import os
+import os.path as op
+import posixpath
+
+from datalad.tests.utils import (
+    with_tempfile,
+    create_tree,
+    assert_equal,
+    assert_dict_equal,
+    assert_in,
+    assert_not_in,
+    ok_clean_git,
+)
+
+from datalad.api import (
+    create,
+)
+
+from datalad_revolution.dataset import RevolutionDataset
+from datalad_revolution.gitrepo import RevolutionGitRepo
+
+
+def _get_convoluted_situation(path):
+    # TODO remove when `create` is RF to return the new Dataset
+    ds = RevolutionDataset(RevolutionDataset(path).create(force=True).path)
+    # base content, all into the annex
+    create_tree(
+        ds.path,
+        {
+            'subdir': {
+                'file_clean': 'file_clean',
+                'file_dropped_clean': 'file_dropped_clean',
+                'file_deleted': 'file_deleted',
+                'file_modified': 'file_clean',
+            },
+            'file_clean': 'file_clean',
+            'file_dropped_clean': 'file_dropped_clean',
+            'file_deleted': 'file_deleted',
+            'file_modified': 'file_clean',
+        }
+    )
+    ds.add('.')
+    # some files straight in git
+    create_tree(
+        ds.path,
+        {
+            'subdir': {
+                'file_ingit_clean': 'file_ingit_clean',
+                'file_ingit_modified': 'file_ingit_clean',
+            },
+            'file_ingit_clean': 'file_ingit_clean',
+            'file_ingit_modified': 'file_ingit_clean',
+        }
+    )
+    ds.add('.', to_git=True)
+    ds.drop([
+        'file_dropped_clean',
+        op.join('subdir', 'file_dropped_clean')],
+        check=False)
+    # clean and proper subdatasets
+    ds.create('subds_clean')
+    ds.create(op.join('subdir', 'subds_clean'))
+    ds.create('subds_unavailable_clean')
+    ds.create(op.join('subdir', 'subds_unavailable_clean'))
+    # uninstall some subdatasets (still clean)
+    ds.uninstall([
+        'subds_unavailable_clean',
+        op.join('subdir', 'subds_unavailable_clean')],
+        check=False)
+    ok_clean_git(ds.path)
+    # staged subds, and files
+    create(op.join(ds.path, 'subds_added'))
+    ds.repo.add_submodule('subds_added')
+    create(op.join(ds.path, 'subdir', 'subds_added'))
+    ds.repo.add_submodule(op.join('subdir', 'subds_added'))
+    # some more untracked files
+    create_tree(
+        ds.path,
+        {
+            'subdir': {
+                'file_untracked': 'file_untracked',
+                'file_added': 'file_added',
+            },
+            'file_untracked': 'file_untracked',
+            'file_added': 'file_added',
+            'dir_untracked': {
+                'file_untracked': 'file_untracked',
+            }
+        }
+    )
+    ds.repo.add(['file_added', op.join('subdir', 'file_added')])
+    # untracked subdatasets
+    create(op.join(ds.path, 'subds_untracked'))
+    create(op.join(ds.path, 'subdir', 'subds_untracked'))
+    # deleted files
+    os.remove(op.join(ds.path, 'file_deleted'))
+    os.remove(op.join(ds.path, 'subdir', 'file_deleted'))
+    # modified files
+    ds.repo.unlock(['file_modified', op.join('subdir', 'file_modified')])
+    create_tree(
+        ds.path,
+        {
+            'subdir': {
+                'file_modified': 'file_modified',
+                'file_ingit_modified': 'file_ingit_modified',
+            },
+            'file_modified': 'file_modified',
+            'file_ingit_modified': 'file_ingit_modified',
+        }
+    )
+    return ds
+
+
+@with_tempfile
+def test_get_content_info(path):
+    repo = RevolutionGitRepo(path)
+    assert_equal(repo.get_content_info(), {})
+
+    ds = _get_convoluted_situation(path)
+
+    # with no reference, the worktree is the reference, hence no deleted
+    # files are reported
+    for f in ds.repo.get_content_annexinfo(init={}, ref=None):
+        assert_not_in('deleted', f)
+    # with a Git reference, nothing staged can be reported
+    for f in ds.repo.get_content_annexinfo(init={}, ref='HEAD'):
+        assert_not_in('added', f)
+
+    # verify general rules on fused info records that are incrementally
+    # assembled: for git content info, ammended with annex info on 'HEAD'
+    # (to get the last commited stage and with it possibly vanished
+    # content), and lastly annex info wrt to the present worktree, to
+    # also get info on added/staged content
+    # this fuses the info reported from
+    # - git ls-files
+    # - git annex findref HEAD
+    # - git annex find --include '*'
+    for f, r in ds.repo.get_content_annexinfo(
+            init=ds.repo.get_content_annexinfo(
+                ref='HEAD',
+                stat_wt=True)).items():
+        if f.endswith('untracked'):
+            assert(r['gitshasum'] is None)
+        if f.endswith('deleted'):
+            assert(r['stat_wt'] is None)
+        if 'subds_' in f:
+                assert(r['type'] == 'dataset' if r['gitshasum'] else 'directory')
+        if 'file_' in f:
+            # which one exactly depends on many things
+            assert_in(r['type'], ('file', 'symlink'))
+        if 'file_ingit' in f:
+            assert(r['type'] == 'file')
+        elif 'datalad' not in f and 'git' not in f and \
+                r['gitshasum'] and 'subds' not in f:
+            # this should be known to annex, one way or another
+            # regardless of whether things add deleted or staged
+            # or anything inbetween
+            assert_in('key', r, f)
+            assert_in('keyname', r, f)
+            assert_in('backend', r, f)
+            assert_in('bytesize', r, f)
+            # no duplication with path
+            assert_not_in('file', r, f)
+
+    # query a single absolute path
+    res = ds.repo.get_content_info(
+        [op.join(ds.path, 'subdir', 'file_clean')])
+    assert_equal(len(res), 1)
+    assert_in(posixpath.join('subdir', 'file_clean'), res)
+
+    # query full untracked report
+    res = ds.repo.get_content_info()
+    assert_in(posixpath.join('dir_untracked', 'file_untracked'), res)
+    assert_not_in('dir_untracked', res)
+    # query for compact untracked report
+    res = ds.repo.get_content_info(untracked='normal')
+    assert_not_in(posixpath.join('dir_untracked', 'file_untracked'), res)
+    assert_in('dir_untracked', res)
+    # query no untracked report
+    res = ds.repo.get_content_info(untracked='no')
+    assert_not_in(posixpath.join('dir_untracked', 'file_untracked'), res)
+    assert_not_in('dir_untracked', res)
+
+    # git status integrity
+    status = ds.repo.status()
+    for t in ('subds', 'file'):
+        for s in ('untracked', 'added', 'deleted', 'clean',
+                  'ingit_clean', 'dropped_clean', 'modified', 'ingit_modified'):
+            for l in ('', posixpath.join('subdir', '')):
+                if t == 'subds' and 'ingit' in s or 'dropped' in s:
+                    # invalid combination
+                    continue
+                if t == 'subds' and s == 'deleted':
+                    # same as subds_unavailable -> clean
+                    continue
+                if t == 'subds' and s == 'modified':
+                    # GitRepo.status() doesn't do that ATM, needs recursion
+                    continue
+                p = '{}{}_{}'.format(l, t, s)
+                assert p.endswith(status[p]['state']), p
+                if t == 'subds':
+                    assert_in(status[p]['type'], ('dataset', 'directory'), p)
+                else:
+                    assert_in(status[p]['type'], ('file', 'symlink'), p)
+
+    # git annex status integrity
+    annexstatus = ds.repo.annexstatus()
+    for t in ('file',):
+        for s in ('untracked', 'added', 'deleted', 'clean',
+                  'ingit_clean', 'dropped_clean', 'modified', 'ingit_modified'):
+            for l in ('', posixpath.join('subdir', '')):
+                p = '{}{}_{}'.format(l, t, s)
+                if s in ('untracked', 'ingit_clean', 'ingit_modified'):
+                    # annex knows nothing about these things
+                    assert_not_in('key', annexstatus[p])
+                    continue
+                assert_in('key', annexstatus[p])
+                assert_equal(annexstatus[p]['has_content'], 'dropped' not in s)
+
+
+@with_tempfile
+def test_compare_content_info(path):
+    # TODO remove when `create` is RF to return the new Dataset
+    ds = RevolutionDataset(RevolutionDataset(path).create().path)
+    ok_clean_git(path)
+
+    # for a clean repo HEAD and worktree query should yield identical results
+    wt = ds.repo.get_content_info(ref=None)
+    assert_dict_equal(wt, ds.repo.get_content_info(ref='HEAD'))

--- a/datalad_revolution/tests/test_fileinfo.py
+++ b/datalad_revolution/tests/test_fileinfo.py
@@ -9,10 +9,7 @@
 
 import os
 import os.path as op
-from pathlib import (
-    Path,
-    PurePosixPath,
-)
+import datalad_revolution.utils as ut
 
 from datalad.tests.utils import (
     with_tempfile,
@@ -133,7 +130,7 @@ def test_get_content_info(path):
     repopath = ds.repo.pathobj
 
     assert_equal(ds.pathobj, repopath)
-    assert_equal(ds.pathobj, Path(path))
+    assert_equal(ds.pathobj, ut.Path(path))
 
     # with no reference, the worktree is the reference, hence no deleted
     # files are reported
@@ -203,7 +200,7 @@ def test_get_content_info(path):
         for s in ('untracked', 'added', 'deleted', 'clean',
                   'ingit_clean', 'dropped_clean', 'modified',
                   'ingit_modified'):
-            for l in ('', PurePosixPath('subdir', '')):
+            for l in ('', ut.PurePosixPath('subdir', '')):
                 if t == 'subds' and 'ingit' in s or 'dropped' in s:
                     # invalid combination
                     continue
@@ -225,7 +222,7 @@ def test_get_content_info(path):
     for t in ('file',):
         for s in ('untracked', 'added', 'deleted', 'clean',
                   'ingit_clean', 'dropped_clean', 'modified', 'ingit_modified'):
-            for l in ('', PurePosixPath('subdir', '')):
+            for l in ('', ut.PurePosixPath('subdir', '')):
                 p = repopath.joinpath(l, '{}_{}'.format(t, s))
                 if s in ('untracked', 'ingit_clean', 'ingit_modified'):
                     # annex knows nothing about these things

--- a/datalad_revolution/tests/utils.py
+++ b/datalad_revolution/tests/utils.py
@@ -1,0 +1,80 @@
+from six import iteritems
+
+from datalad_revolution.gitrepo import RevolutionGitRepo as GitRepo
+from datalad_revolution.annexrepo import RevolutionAnnexRepo as AnnexRepo
+
+from datalad.tests.utils import (
+    eq_,
+    assert_is,
+)
+
+
+def assert_repo_status(path, annex=None, untracked_mode='normal', **kwargs):
+    """Compare a repo status against (optional) exceptions.
+
+    Anything file/directory that is not explicitly indicated must have
+    state 'clean', i.e. no modifications and recorded in Git.
+
+    This is an alternative to the traditional `ok_clean_git` helper.
+
+    Parameters
+    ----------
+    path: str or Repo
+      in case of a str: path to the repository's base dir;
+      Note, that passing a Repo instance prevents detecting annex. This might
+      be useful in case of a non-initialized annex, a GitRepo is pointing to.
+    annex: bool or None
+      explicitly set to True or False to indicate, that an annex is (not)
+      expected; set to None to autodetect, whether there is an annex.
+      Default: None.
+    untracked_mode: {'no', 'normal', 'all'}
+      If and how untracked content is reported. The specification of untracked
+      files that are OK to be found must match this mode. See `Repo.status()`
+    **kwargs
+      Files/directories that are OK to not be in 'clean' state. Each argument
+      must be one of 'added', 'untracked', 'deleted', 'modified' and each
+      value must be a list of filenames (relative to the root of the
+      repository.
+    """
+    r = None
+    if isinstance(path, AnnexRepo):
+        if annex is None:
+            annex = True
+        # if `annex` was set to False, but we find an annex => fail
+        assert_is(annex, True)
+        r = path
+    elif isinstance(path, GitRepo):
+        if annex is None:
+            annex = False
+        # explicitly given GitRepo instance doesn't make sense with
+        # 'annex' True
+        assert_is(annex, False)
+        r = path
+    else:
+        # 'path' is an actual path
+        try:
+            r = AnnexRepo(path, init=False, create=False)
+            if annex is None:
+                annex = True
+            # if `annex` was set to False, but we find an annex => fail
+            assert_is(annex, True)
+        except Exception:
+            # Instantiation failed => no annex
+            try:
+                r = GitRepo(path, init=False, create=False)
+            except Exception:
+                raise AssertionError("Couldn't find an annex or a git "
+                                     "repository at {}.".format(path))
+            if annex is None:
+                annex = False
+            # explicitly given GitRepo instance doesn't make sense with
+            # 'annex' True
+            assert_is(annex, False)
+
+    status = r.status(untracked=untracked_mode)
+    # for any file state that indicates some kind of change (all but 'clean)
+    for state in ('added', 'untracked', 'deleted', 'modified'):
+        oktobefound = kwargs.get(state, [])
+        state_files = [k for k, v in iteritems(status)
+                       if v.get('state', None) == state]
+        eq_(sorted(state_files), sorted(oktobefound))

--- a/datalad_revolution/tests/utils.py
+++ b/datalad_revolution/tests/utils.py
@@ -74,7 +74,9 @@ def assert_repo_status(path, annex=None, untracked_mode='normal', **kwargs):
     status = r.status(untracked=untracked_mode)
     # for any file state that indicates some kind of change (all but 'clean)
     for state in ('added', 'untracked', 'deleted', 'modified'):
-        oktobefound = kwargs.get(state, [])
-        state_files = [k for k, v in iteritems(status)
-                       if v.get('state', None) == state]
-        eq_(sorted(state_files), sorted(oktobefound))
+        oktobefound = sorted(kwargs.get(state, []))
+        state_files = sorted(k for k, v in iteritems(status)
+                             if v.get('state', None) == state)
+        eq_(state_files, oktobefound,
+            'unexpected content of state "%s": %r != %r'
+            % (state, state_files, oktobefound))

--- a/datalad_revolution/utils.py
+++ b/datalad_revolution/utils.py
@@ -1,2 +1,17 @@
+
+# handle this dance once, and import pathlib from here
+# in all other places
+try:
+    from pathlib import (
+        Path,
+        PurePosixPath,
+    )
+except ImportError:
+    from pathlib2 import (
+        Path,
+        PurePosixPath,
+    )
+
+
 def nothere(*args, **kwargs):
     raise NotImplementedError

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         # aspect is an optional component of a larger project
         # disable for now as we currently need a Git snapshot (requirements.txt)
         'datalad',
+        'pathlib2; python_version < "3.0"',
     ],
     entry_points = {
         # 'datalad.extensions' is THE entrypoint inspected by the datalad API builders


### PR DESCRIPTION
This is a revival of https://github.com/datalad/datalad/pull/2882 but does not include some of the RFs of commands that are not in scope here.

### Problem being addressed

ATM we have low-level helpers that can query individual aspects of dataset content properties (`is_under_annex`, `file_has_content`, ...). Moroever, we never had a general purpose `status()` for Git repositories. Both aspects combined lead to a particular way of processing: We limits the paths that need attention in a particular case to the smallest possible subset through a series of queries, and then act upon them (path annotation approach etc...). Queries tend to be expensive (frequently lead to a dedicated git/annex call per aspect or sometimes even per path). This has the potential to be slow.

### Core idea

Implement a minimum number of helpers that can extract a maximum number of information from git/annex with the least number of git calls. The theme being to get as much in one go as possible that has no significant penalties in terms of file system access. It should become possible to get a tailored view on the state of a *single* repository without having to invent approaches and data structures for each use case. In this concept, one would err on the side of getting too much information, rather then too little. This would them allow for RFs of commands where tracking state information across various levels is crucial (i.e. `save`) and the present implementation do a good job of confusing users and authors ;-)

In terms of v6 compatibility, emphasis is put on only using Git/annex API calls that work in all scenarios and perform test of filesystem representation only for a few select aspects that generalize well.

### Major changes
- [x] `GitRepo.get_content_info()` as a frontend for `ls-files/tree` to get type, shasum and path of anything known to git, or detectable by its change-detection mechanism (incl. untracked content)
- [x] `AnnexRepo.get_content_annexinfo()` as a frontend for `find/findref` to get basic annex properties for anything known to annex
- [x] `GitRepo.status()` to report the difference between `HEAD` and the worktree. Possible states can be: 'added', 'untracked', 'clean', 'deleted', 'modified'
- [x] `AnnexRepo.annexstatus()` to amend `GitRepo.status()` with info on local content availability of annex'ed files.
- [x] make annex content availability accessible without a call to `status()` for enhanced speed
- [x] switch to `pathlib` path objects for speed and automatic cross-platform handling

### Notes

- status functions are not called `get_*status()` yet, because there is `AnnexRepo.get_status()` that does one aspect of the proposed functionality in a different way. It should likely be removed, but at present `GitRepo.status()` does not (and does not want to) detect subdataset modification, as it requires dataset traversal and is better done in top-level code IMHO.