### PR TITLE
NF: Initial sketch of a `status` command

### DIFF
--- a/datalad_revolution/__init__.py
+++ b/datalad_revolution/__init__.py
@@ -39,6 +39,12 @@ command_suite = (
             'rev-create',
             'rev_create'
         ),
+        (
+            'datalad_revolution.revstatus',
+            'RevStatus',
+            'rev-status',
+            'rev_status'
+        ),
     ]
 )
 

--- a/datalad_revolution/dataset.py
+++ b/datalad_revolution/dataset.py
@@ -177,9 +177,10 @@ def resolve_path(path, ds=None):
         return ut.Path(path)
 
     # we have a dataset
-    if not op.isabs(path) and \
-            not (path.startswith(os.curdir + os.sep) or
-                 path.startswith(os.pardir + os.sep)):
+    # stringify in case a pathobj came in
+    if not op.isabs(str(path)) and \
+            not (str(path).startswith(os.curdir + os.sep) or
+                 str(path).startswith(os.pardir + os.sep)):
         # we have a dataset and no abspath nor an explicit relative path ->
         # resolve it against the dataset
         return ds.pathobj / path

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -237,7 +237,9 @@ class RevolutionGitRepo(GitRepo):
             modified = set(
                 self.pathobj.joinpath(ut.PurePosixPath(p))
                 for p in self._git_custom_command(
-                    paths, ['git', 'ls-files', '-z', '-m'])[0].split('\0')
+                    # low-level code cannot handle pathobjs
+                    [str(p) for p in paths] if paths else None,
+                    ['git', 'ls-files', '-z', '-m'])[0].split('\0')
                 if p)
         else:
             to_state = self.get_content_info(paths=paths, ref=to)

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -1,0 +1,194 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Report status of a dataset (hierarchy)'s work tree"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+import os.path as op
+from six import iteritems
+from collections import OrderedDict
+
+from datalad.utils import (
+    assure_list,
+    get_dataset_root,
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.utils import eval_results
+from datalad.interface.common_opts import (
+    recursion_limit,
+    recursion_flag,
+)
+
+from datalad_revolution.dataset import (
+    RevolutionDataset as Dataset,
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+    resolve_path,
+)
+import datalad_revolution.utils as ut
+
+from datalad.support.constraints import EnsureNone
+from datalad.support.constraints import EnsureStr
+from datalad.support.constraints import EnsureChoice
+from datalad.support.param import Parameter
+
+lgr = logging.getLogger('datalad.revolution.status')
+
+
+def _yield_status(ds, paths, untracked, recursion_limit, queried):
+    # take the datase that went in first
+    repo_path = ds.repo.pathobj
+    lgr.debug('query %s.status() for paths: %s', ds.repo, paths)
+    for path, props in iteritems(ds.repo.status(
+            paths=paths if paths else None,
+            untracked=untracked,
+            # TODO think about potential optimizations in case of
+            # recursive processing, as this will imply a semi-recursive
+            # look into subdatasets
+            ignore_submodules='other')):
+        cpath = ds.pathobj / path.relative_to(repo_path)
+        yield dict(
+            props,
+            path=cpath,
+        )
+        queried.add(ds.pathobj)
+        if recursion_limit and props.get('type', None) == 'dataset':
+            subds = Dataset(str(cpath))
+            if subds.is_installed():
+                for r in _yield_status(
+                        subds,
+                        None,
+                        untracked,
+                        recursion_limit - 1,
+                        queried):
+                    yield r
+
+
+@build_doc
+class RevStatus(Interface):
+    """
+    """
+
+    # make the custom renderer the default one, as the global default renderer
+    # does not yield meaningful output for this command
+    result_renderer = 'tailored'
+
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the dataset to query.  If
+            no dataset is given, an attempt is made to identify the dataset
+            based on the input and/or the current working directory""",
+            constraints=EnsureDataset() | EnsureNone()),
+        path=Parameter(
+            args=("path",),
+            metavar="PATH",
+            doc="""path to be evaluated""",
+            nargs="*",
+            constraints=EnsureStr() | EnsureNone()),
+        untracked=Parameter(
+            args=('--untracked',),
+            constraints=EnsureChoice('no', 'normal', 'all'),
+            doc="""If and how untracked content is reported when comparing
+            a revision to the state of the work tree. 'no': no untracked files
+            are reported; 'normal': untracked files and entire untracked
+            directories are reported as such; 'all': report individual files
+            even in fully untracked directories."""),
+        recursive=recursion_flag,
+        recursion_limit=recursion_limit)
+
+    @staticmethod
+    @datasetmethod(name='rev_status')
+    @eval_results
+    def __call__(
+            path=None,
+            dataset=None,
+            untracked='normal',
+            recursive=False,
+            recursion_limit=None):
+        ds = require_dataset(
+            dataset, check_installed=True, purpose='status reporting')
+
+        paths = []
+        if path:
+            # convert to pathobjs, decoding datalad path semantics
+            path = [resolve_path(p, dataset) for p in assure_list(path)]
+
+            # error on non-dataset paths
+            for p in path:
+                try:
+                    relp = p.resolve().relative_to(ds.repo.pathobj)
+                    paths.append(ds.pathobj / relp)
+                except ValueError as e:
+                    yield dict(
+                        action='status',
+                        path=p,
+                        refds=ds.pathobj,
+                        status='error',
+                        message='path not underneath this dataset',
+                        logger=lgr)
+                    # exit early at the cost of not reporting potential
+                    # further errors
+                    return
+
+        paths_by_ds = OrderedDict()
+        if paths:
+            for p in sorted(paths):
+                root = ut.Path(get_dataset_root(p))
+                ps = paths_by_ds.get(root, [])
+                if p != root:
+                    ps.append(p)
+                paths_by_ds[root] = ps
+        else:
+            paths_by_ds[ds.pathobj] = None
+
+        queried = set()
+        while paths_by_ds:
+            qdspath, qpaths = paths_by_ds.popitem(last=False)
+            if qdspath in queried:
+                continue
+            qds = Dataset(str(qdspath))
+            for r in _yield_status(
+                    qds,
+                    qpaths,
+                    untracked,
+                    recursion_limit
+                    if recursion_limit is not None else -1
+                    if recursive else 0,
+                    queried):
+                yield dict(
+                    r,
+                    refds=ds.pathobj,
+                    action='status',
+                    status='ok',
+                )
+
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):
+        from datalad.ui import ui
+        if not res['status'] == 'ok' or res.get('state', None) == 'clean':
+            # logging reported already
+            return
+        path = op.relpath(res['path'], start=res['refds']) \
+            if res.get('refds', None) else res['path']
+        type_ = res.get('type', res.get('type_src', ''))
+        max_len = len('untracked(directory)')
+        state_msg = '{}{}'.format(
+            res['state'],
+            '({})'.format(type_ if type_ else ''))
+        ui.message('{fill}{state_msg}: {path}'.format(
+            fill=' ' * max(0, max_len - len(state_msg)),
+            state_msg=state_msg,
+            path=path))

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -152,7 +152,8 @@ class RevStatus(Interface):
         paths_by_ds = OrderedDict()
         if paths:
             for p in sorted(paths):
-                root = ut.Path(get_dataset_root(p))
+                # TODO have a better get_dataset_root that takes Pathobjs
+                root = ut.Path(get_dataset_root(str(p)))
                 ps = paths_by_ds.get(root, [])
                 if p != root:
                     ps.append(p)

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -181,7 +181,7 @@ class RevStatus(Interface):
         if not res['status'] == 'ok' or res.get('state', None) == 'clean':
             # logging reported already
             return
-        path = op.relpath(res['path'], start=res['refds']) \
+        path = res['path'].relative_to(res['refds']) \
             if res.get('refds', None) else res['path']
         type_ = res.get('type', res.get('type_src', ''))
         max_len = len('untracked(directory)')

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -176,7 +176,7 @@ class RevStatus(Interface):
                 )
 
     @staticmethod
-    def custom_result_renderer(res, **kwargs):
+    def custom_result_renderer(res, **kwargs):  # pragma: no cover
         from datalad.ui import ui
         if not res['status'] == 'ok' or res.get('state', None) == 'clean':
             # logging reported already

--- a/datalad_revolution/tests/test_status.py
+++ b/datalad_revolution/tests/test_status.py
@@ -1,0 +1,137 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test status command"""
+
+import os.path as op
+import datalad_revolution.utils as ut
+
+from datalad.utils import (
+    chpwd,
+    on_windows,
+)
+from datalad.tests.utils import (
+    eq_,
+    assert_in,
+    assert_raises,
+    assert_status,
+    assert_result_count,
+    with_tempfile,
+)
+from datalad.support.exceptions import (
+    NoDatasetArgumentFound,
+    IncompleteResultsError,
+)
+from datalad_revolution.dataset import RevolutionDataset as Dataset
+from datalad_revolution.tests.utils import (
+    get_deeply_nested_structure,
+)
+from datalad.api import (
+    rev_status as status,
+)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile()
+@with_tempfile(mkdir=True)
+def test_status_basics(path, linkpath, otherdir):
+    if not on_windows:
+        # make it more complicated by default
+        ut.Path(linkpath).symlink_to(path, target_is_directory=True)
+        path = linkpath
+
+    with chpwd(path):
+        assert_raises(NoDatasetArgumentFound, status)
+    ds = Dataset(path).rev_create()
+    # outcome identical between ds= and auto-discovery
+    with chpwd(path):
+        assert_raises(IncompleteResultsError, status, path=otherdir)
+        stat = status()
+    eq_(stat, ds.rev_status())
+    assert_status('ok', stat)
+    # we have a bunch of reports (be vague to be robust to future changes
+    assert len(stat) > 2
+    # check the composition
+    for s in stat:
+        # all paths are native path objects
+        assert isinstance(s['path'], ut.Path)
+        eq_(s['status'], 'ok')
+        eq_(s['action'], 'status')
+        eq_(s['state'], 'clean')
+        eq_(s['type'], 'file')
+        assert_in('gitshasum', s)
+        eq_(s['refds'], ds.pathobj)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile()
+def test_status(_path, linkpath):
+    # do the setup on the real path, not the symlink to have its
+    # bugs not affect this test of status()
+    ds = get_deeply_nested_structure(str(_path))
+    if not on_windows:
+        # make it more complicated by default
+        ut.Path(linkpath).symlink_to(_path, target_is_directory=True)
+        path = linkpath
+    else:
+        path = _path
+
+    ds = Dataset(path)
+    if not on_windows:
+        # check the premise of this test
+        assert ds.pathobj != ds.repo.pathobj
+
+    # bunch of smoke tests
+    plain_recursive = ds.rev_status(recursive=True)
+    # query of '.' is same as no path
+    eq_(plain_recursive, ds.rev_status(path='.', recursive=True))
+    # duplicate paths do not change things
+    eq_(plain_recursive, ds.rev_status(path=['.', '.'], recursive=True))
+    # neither do nested paths
+    eq_(plain_recursive,
+        ds.rev_status(path=['.', 'subds_modified'], recursive=True))
+    # when invoked in a subdir of a dataset it still reports on the full thing
+    # just like `git status`, as long as there are no paths specified
+    with chpwd(op.join(path, 'directory_untracked')):
+        plain_recursive = status(recursive=True)
+
+    # query for a deeply nested path from the top, should just work with a
+    # variety of approaches
+    rpath = op.join('subds_modified', 'subds_lvl1_modified',
+                    'directory_untracked')
+    apathobj = ds.pathobj / rpath
+    apath = str(apathobj)
+    # ds.repo.pathobj will have the symlink resolved
+    arealpath = ds.repo.pathobj / rpath
+    for p in (rpath, apath, arealpath):
+        assert_result_count(
+            ds.rev_status(path=p),
+            1,
+            state='untracked',
+            type='directory',
+            refds=ds.pathobj,
+            # path always comes out a full path inside the queried dataset
+            path=apathobj,
+        )
+
+    assert_result_count(
+        ds.rev_status(
+            recursive=True),
+        1,
+        path=apathobj)
+    # limiting recursion will exclude this particular path
+    assert_result_count(
+        ds.rev_status(
+            recursive=True,
+            recursion_limit=1),
+        0,
+        path=apathobj)
+    # negative limit is unlimited limit
+    eq_(
+        ds.rev_status(recursive=True, recursion_limit=-1),
+        ds.rev_status(recursive=True)
+    )

--- a/datalad_revolution/tests/utils.py
+++ b/datalad_revolution/tests/utils.py
@@ -230,3 +230,16 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
         }
     )
     return ds
+
+
+def get_deeply_nested_structure(path):
+    ds = Dataset(path).rev_create()
+    (ds.pathobj / 'directory_untracked').mkdir()
+    # a subtree of datasets
+    ds.create('subds_modified')
+    # another dataset, plus an addition dir in it
+    (Dataset(
+        ds.create(
+            op.join('subds_modified', 'subds_lvl1_modified')
+        ).path).pathobj / 'directory_untracked').mkdir()
+    return ds


### PR DESCRIPTION
This is the first command that is fully using the new functionality. There are many open issues (more fundamental than the scope of this PR and also relevant for datalad-core), but it is already quite functional.

Please try it out.

Teaser:

```
% python -c 'from datalad_revolution.tests.utils import get_convoluted_situation; get_convoluted_situation(".")'
...
python -c   13.65s user 8.48s system 102% cpu 21.515 total
```
![image](https://user-images.githubusercontent.com/136479/47084770-df293a00-d214-11e8-9d75-8b1c9813129f.png)
