### PR TITLE
ENH: Improved path resolution in `rev-status`

### DIFF
--- a/datalad_revolution/dataset.py
+++ b/datalad_revolution/dataset.py
@@ -2,7 +2,10 @@ __docformat__ = 'restructuredtext'
 
 import os
 import os.path as op
-from six import PY2
+from six import (
+    PY2,
+    text_type,
+)
 import wrapt
 import logging
 import datalad_revolution.utils as ut
@@ -196,7 +199,7 @@ def resolve_path(path, ds=None):
 
 def path_under_dataset(ds, path):
     ds_path = ds.pathobj
-    root = get_dataset_root(path)
+    root = get_dataset_root(text_type(path))
     while root is not None and not ds_path.samefile(root):
         root = get_dataset_root(op.dirname(root))
     if root is None:

--- a/datalad_revolution/dataset.py
+++ b/datalad_revolution/dataset.py
@@ -201,7 +201,12 @@ def path_under_dataset(ds, path):
     ds_path = ds.pathobj
     root = get_dataset_root(text_type(path))
     while root is not None and not ds_path.samefile(root):
-        root = get_dataset_root(op.dirname(root))
+        # path and therefore root could be relative paths,
+        # hence in the next round we cannot use dirname()
+        # to jump in the the next directory up, but we have
+        # to use ./.. and get_dataset_root() will handle
+        # the rest just fine
+        root = get_dataset_root(op.join(root, op.pardir))
     if root is None:
         return None
-    return ds_path / op.relpath(path, root)
+    return ds_path / op.relpath(text_type(path), root)

--- a/datalad_revolution/dataset.py
+++ b/datalad_revolution/dataset.py
@@ -18,7 +18,10 @@ from datalad.support.gitrepo import (
     NoSuchPathError,
 )
 
-from datalad.utils import optional_args
+from datalad.utils import (
+    optional_args,
+    get_dataset_root,
+)
 
 from datalad_revolution.gitrepo import RevolutionGitRepo
 from datalad_revolution.annexrepo import RevolutionAnnexRepo
@@ -189,3 +192,13 @@ def resolve_path(path, ds=None):
     # pathlib docs for why this is the only sane choice in the
     # face of the possibility of symlinks in the path
     return ut.Path(path)
+
+
+def path_under_dataset(ds, path):
+    ds_path = ds.pathobj
+    root = get_dataset_root(path)
+    while root is not None and not ds_path.samefile(root):
+        root = get_dataset_root(op.dirname(root))
+    if root is None:
+        return None
+    return ds_path / op.relpath(path, root)

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -321,7 +321,12 @@ class RevolutionGitRepo(GitRepo):
             else:
                 # the recorded commit did not change, so we need to make
                 # a more expensive traversal
-                rstatus = subrepo.status(
+                rstatus = subrepo.diffstatus(
+                    # we can use 'HEAD' because we know that the commit
+                    # did not change. using 'HEAD' will facilitate
+                    # caching the result
+                    fr='HEAD',
+                    to=None,
                     paths=None,
                     untracked=untracked,
                     # TODO could be RF'ed to stop after the first find

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -226,8 +226,14 @@ class RevolutionGitRepo(GitRepo):
             if v.get('state', None) != 'clean'}
 
     def diffstatus(self, fr, to, paths=None, untracked='all',
-                   ignore_submodules='no'):
+                   ignore_submodules='no', _cache=None):
         """Like diff(), but reports the status of 'clean' content too"""
+        def _get_cache_key(label, paths, ref, untracked=None):
+            return self.path, label, tuple(paths) if paths else None, \
+                ref, untracked
+
+        if _cache is None:
+            _cache = {}
         # TODO report more info from get_content_info() calls in return
         # value, those are cheap and possibly useful to a consumer
         status = OrderedDict()
@@ -235,23 +241,43 @@ class RevolutionGitRepo(GitRepo):
         if to is None:
             # everything we know about the worktree, including os.stat
             # for each file
-            to_state = self.get_content_info(
-                paths=paths, ref=None, untracked=untracked)
+            key = _get_cache_key('ci', paths, None, untracked)
+            if key in _cache:
+                to_state = _cache[key]
+            else:
+                to_state = self.get_content_info(
+                    paths=paths, ref=None, untracked=untracked)
+                _cache[key] = to_state
             # we want Git to tell us what it considers modified and avoid
             # reimplementing logic ourselves
-            modified = set(
-                self.pathobj.joinpath(ut.PurePosixPath(p))
-                for p in self._git_custom_command(
-                    # low-level code cannot handle pathobjs
-                    [str(p) for p in paths] if paths else None,
-                    ['git', 'ls-files', '-z', '-m'])[0].split('\0')
-                if p)
+            key = _get_cache_key('mod', paths, None)
+            if key in _cache:
+                modified = _cache[key]
+            else:
+                modified = set(
+                    self.pathobj.joinpath(ut.PurePosixPath(p))
+                    for p in self._git_custom_command(
+                        # low-level code cannot handle pathobjs
+                        [str(p) for p in paths] if paths else None,
+                        ['git', 'ls-files', '-z', '-m'])[0].split('\0')
+                    if p)
+                _cache[key] = modified
         else:
-            to_state = self.get_content_info(paths=paths, ref=to)
+            key = _get_cache_key('ci', paths, to)
+            if key in _cache:
+                to_state = _cache[key]
+            else:
+                to_state = self.get_content_info(paths=paths, ref=to)
+                _cache[key] = to_state
             # we do not need worktree modification detection in this case
             modified = None
         # origin state
-        from_state = self.get_content_info(paths=paths, ref=fr)
+        key = _get_cache_key('ci', paths, fr)
+        if key in _cache:
+            from_state = _cache[key]
+        else:
+            from_state = self.get_content_info(paths=paths, ref=fr)
+            _cache[key] = to_state
 
         for f, to_state_r in iteritems(to_state):
             props = None
@@ -332,7 +358,8 @@ class RevolutionGitRepo(GitRepo):
                     # TODO could be RF'ed to stop after the first find
                     # of a modified subdataset
                     # ATM implementation performs an exhaustive search
-                    ignore_submodules='other')
+                    ignore_submodules='other',
+                    _cache=_cache)
                 if any(v['state'] != 'clean'
                        for k, v in iteritems(rstatus)):
                     st['state'] = 'modified'

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -63,7 +63,9 @@ def _yield_status(ds, paths, untracked, recursion_limit, queried):
     # take the datase that went in first
     repo_path = ds.repo.pathobj
     lgr.debug('query %s.status() for paths: %s', ds.repo, paths)
-    for path, props in iteritems(ds.repo.status(
+    for path, props in iteritems(ds.repo.diffstatus(
+            fr='HEAD',
+            to=None,
             paths=paths if paths else None,
             untracked=untracked,
             # TODO think about potential optimizations in case of

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -90,7 +90,43 @@ def _yield_status(ds, paths, untracked, recursion_limit, queried):
 
 @build_doc
 class RevStatus(Interface):
-    """
+    """Report on the state of dataset content.
+
+    This is an analog to `git status` that is simultaneously crippled and more
+    powerful. It is crippled, because it only supports a fraction of the
+    functionality of its counter part and only distinguishes a subset of the
+    states that Git knows about. But it is also more powerful as it can handle
+    status reports for a whole hierarchy of datasets, with the ability to
+    report on a subset of the content (selection of paths) across any number
+    of datasets in the hierarchy.
+
+    All reports are guaranteed to use absolute paths that are underneath the
+    given or detected reference dataset, regardless of whether query paths are
+    given as absolute or relative paths (with respect to the working directory,
+    or to the reference dataset, when such a dataset is given explicitly).
+    Moreover, so-called "explicit relative paths" (i.e. paths that start with
+    '.' or '..') are also supported, and are interpreted as relative paths with
+    respect to the current working directory regardless of whether a reference
+    dataset with specified.
+
+    *Content types*
+
+    The following content types are distinguished:
+
+    - 'file'
+    - 'symlink'
+    - 'dataset'
+    - 'directory'
+
+    *Content states*
+
+    The following content states are distinguished:
+
+    - 'clean'
+    - 'added'
+    - 'modified'
+    - 'deleted'
+    - 'untracked'
     """
     # make the custom renderer the default one, as the global default renderer
     # does not yield meaningful output for this command

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -59,7 +59,7 @@ state_color_map = {
 }
 
 
-def _yield_status(ds, paths, untracked, recursion_limit, queried):
+def _yield_status(ds, paths, untracked, recursion_limit, queried, cache):
     # take the datase that went in first
     repo_path = ds.repo.pathobj
     lgr.debug('query %s.status() for paths: %s', ds.repo, paths)
@@ -71,7 +71,8 @@ def _yield_status(ds, paths, untracked, recursion_limit, queried):
             # TODO think about potential optimizations in case of
             # recursive processing, as this will imply a semi-recursive
             # look into subdatasets
-            ignore_submodules='other')):
+            ignore_submodules='other',
+            _cache=cache)):
         cpath = ds.pathobj / path.relative_to(repo_path)
         yield dict(
             props,
@@ -86,7 +87,8 @@ def _yield_status(ds, paths, untracked, recursion_limit, queried):
                         None,
                         untracked,
                         recursion_limit - 1,
-                        queried):
+                        queried,
+                        cache):
                     yield r
 
 
@@ -195,6 +197,7 @@ class RevStatus(Interface):
             paths_by_ds[ds.pathobj] = None
 
         queried = set()
+        content_info_cache = {}
         while paths_by_ds:
             qdspath, qpaths = paths_by_ds.popitem(last=False)
             # try to recode the dataset path wrt to the reference
@@ -233,7 +236,8 @@ class RevStatus(Interface):
                     recursion_limit
                     if recursion_limit is not None else -1
                     if recursive else 0,
-                    queried):
+                    queried,
+                    content_info_cache):
                 yield dict(
                     r,
                     refds=ds.pathobj,

--- a/datalad_revolution/tests/test_status.py
+++ b/datalad_revolution/tests/test_status.py
@@ -68,6 +68,17 @@ def test_status_basics(path, linkpath, otherdir):
 
 
 @with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_status_nods(path, otherpath):
+    ds = Dataset(path).rev_create()
+    assert_result_count(
+        ds.rev_status(path=otherpath, on_failure='ignore'),
+        1,
+        status='error',
+        message='path not underneath this dataset')
+
+
+@with_tempfile(mkdir=True)
 @with_tempfile()
 def test_status(_path, linkpath):
     # do the setup on the real path, not the symlink to have its

--- a/datalad_revolution/tests/test_status.py
+++ b/datalad_revolution/tests/test_status.py
@@ -107,9 +107,7 @@ def test_status(_path, linkpath):
         assert ds.pathobj != ds.repo.pathobj
 
     # bunch of smoke tests
-    print("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$")
     plain_recursive = ds.rev_status(recursive=True)
-    print("#####################################")
     # query of '.' is same as no path
     eq_(plain_recursive, ds.rev_status(path='.', recursive=True))
     # duplicate paths do not change things

--- a/datalad_revolution/tests/test_status.py
+++ b/datalad_revolution/tests/test_status.py
@@ -98,6 +98,9 @@ def test_status(_path, linkpath):
     # just like `git status`, as long as there are no paths specified
     with chpwd(op.join(path, 'directory_untracked')):
         plain_recursive = status(recursive=True)
+    # should be able to take absolute paths and yield the same
+    # output
+    eq_(plain_recursive, ds.rev_status(path=ds.path, recursive=True))
 
     # query for a deeply nested path from the top, should just work with a
     # variety of approaches
@@ -107,6 +110,7 @@ def test_status(_path, linkpath):
     apath = str(apathobj)
     # ds.repo.pathobj will have the symlink resolved
     arealpath = ds.repo.pathobj / rpath
+    # TODO include explicit relative path in test
     for p in (rpath, apath, arealpath):
         assert_result_count(
             ds.rev_status(path=p),

--- a/datalad_revolution/tests/test_status.py
+++ b/datalad_revolution/tests/test_status.py
@@ -76,6 +76,16 @@ def test_status_nods(path, otherpath):
         1,
         status='error',
         message='path not underneath this dataset')
+    otherds = Dataset(otherpath).rev_create()
+    assert_result_count(
+        ds.rev_status(path=otherpath, on_failure='ignore'),
+        1,
+        path=otherds.path,
+        status='error',
+        message=(
+            'dataset containing given paths is not underneath the reference dataset %s: %s',
+            ds, [])
+        )
 
 
 @with_tempfile(mkdir=True)
@@ -97,7 +107,9 @@ def test_status(_path, linkpath):
         assert ds.pathobj != ds.repo.pathobj
 
     # bunch of smoke tests
+    print("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$")
     plain_recursive = ds.rev_status(recursive=True)
+    print("#####################################")
     # query of '.' is same as no path
     eq_(plain_recursive, ds.rev_status(path='.', recursive=True))
     # duplicate paths do not change things

--- a/datalad_revolution/tests/test_status.py
+++ b/datalad_revolution/tests/test_status.py
@@ -111,9 +111,16 @@ def test_status(_path, linkpath):
     # ds.repo.pathobj will have the symlink resolved
     arealpath = ds.repo.pathobj / rpath
     # TODO include explicit relative path in test
-    for p in (rpath, apath, arealpath):
+    for p in (rpath, apath, arealpath, None):
+        if p is None:
+            # change into the realpath of the dataset and
+            # query with an explicit path
+            with chpwd(ds.repo.path):
+                res = ds.rev_status(path=op.join('.', rpath))
+        else:
+            res = ds.rev_status(path=p)
         assert_result_count(
-            ds.rev_status(path=p),
+            res,
             1,
             state='untracked',
             type='directory',


### PR DESCRIPTION
Seemlessly deal with realpaths and report paths underneath a symlinked
dataset path regardless