### PR TITLE
A leaner `create`

### DIFF
--- a/datalad_revolution/revcreate.py
+++ b/datalad_revolution/revcreate.py
@@ -18,8 +18,6 @@ from six import iteritems
 
 from os import listdir
 import os.path as op
-from os.path import isdir
-from os.path import join as opj
 
 from datalad import cfg
 from datalad import _seed
@@ -27,17 +25,21 @@ from datalad.interface.base import Interface
 from datalad.interface.annotate_paths import AnnotatePaths
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
-from datalad.interface.common_opts import git_opts
-from datalad.interface.common_opts import annex_opts
-from datalad.interface.common_opts import annex_init_opts
-from datalad.interface.common_opts import location_description
-from datalad.interface.common_opts import nosave_opt
-from datalad.interface.common_opts import shared_access_opt
+from datalad.interface.common_opts import (
+    git_opts,
+    annex_opts,
+    annex_init_opts,
+    location_description,
+    nosave_opt,
+    shared_access_opt,
+)
 from datalad.interface.results import ResultXFM
-from datalad.support.constraints import EnsureStr
-from datalad.support.constraints import EnsureNone
-from datalad.support.constraints import EnsureKeyChoice
-from datalad.support.constraints import EnsureDType
+from datalad.support.constraints import (
+    EnsureStr,
+    EnsureNone,
+    EnsureKeyChoice,
+    EnsureDType,
+)
 from datalad.support.param import Parameter
 from datalad.utils import getpwd
 from datalad.distribution.subdatasets import Subdatasets
@@ -61,7 +63,7 @@ import datalad_revolution.utils as ut
 
 __docformat__ = 'restructuredtext'
 
-lgr = logging.getLogger('datalad.distribution.create')
+lgr = logging.getLogger('datalad.revolution.create')
 
 
 # TODO for now carry a copy of this one, until datalad-core returns
@@ -357,7 +359,7 @@ class RevCreate(Interface):
             else Dataset(path['path'])
 
         # don't create in non-empty directory without `force`:
-        if isdir(tbds.path) and listdir(tbds.path) != [] and not force:
+        if op.isdir(tbds.path) and listdir(tbds.path) != [] and not force:
             path.update({
                 'status': 'error',
                 'message':

--- a/datalad_revolution/revcreate.py
+++ b/datalad_revolution/revcreate.py
@@ -285,7 +285,7 @@ class RevCreate(Interface):
         # in this location
         # it will cost some filesystem traversal though...
         parentds_path = get_dataset_root(
-            op.normpath(op.join(path, os.pardir)))
+            op.normpath(op.join(str(path), os.pardir)))
         if parentds_path:
             # we cannot get away with a simple
             # GitRepo.get_content_info(), as we need to detect

--- a/datalad_revolution/revcreate.py
+++ b/datalad_revolution/revcreate.py
@@ -339,6 +339,12 @@ class RevCreate(Interface):
                 create=True,
                 git_opts=git_opts,
                 fake_dates=fake_dates)
+            # place a .noannex file to indicate annex to leave this repo alone
+            stamp_path = ut.Path(tbds.path) / '.noannex'
+            stamp_path.touch()
+            add_to_git[stamp_path] = {
+                'type': 'file',
+                'state': 'untracked'}
         else:
             # always come with annex when created from scratch
             lgr.info("Creating a new annex repo at %s", tbds.path)

--- a/datalad_revolution/revcreate.py
+++ b/datalad_revolution/revcreate.py
@@ -235,17 +235,6 @@ class RevCreate(Interface):
                         dataset, str(path)),
                 )
                 return
-        if orig_path and dataset and refds is None:
-            # Given a path and a dataset (path) not pointing to installed
-            # dataset
-                msg = "No installed dataset at %s found." % dataset.path
-                dsroot = get_dataset_root(dataset.path)
-                if dsroot:
-                    msg += " If you meant to add to the %s dataset, use that path " \
-                           "instead but remember that if dataset is provided, " \
-                           "relative paths are relative to the top of the " \
-                           "dataset." % dsroot
-                raise ValueError(msg)
 
         # try to locate an immediate parent dataset
         # we want to know this (irrespective of whether we plan on adding
@@ -414,7 +403,7 @@ class RevCreate(Interface):
         yield res
 
     @staticmethod
-    def custom_result_renderer(res, **kwargs):
+    def custom_result_renderer(res, **kwargs):  # pragma: no cover
         from datalad.ui import ui
         if res.get('action', None) == 'create' and \
                res.get('status', None) == 'ok' and \

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -247,7 +247,7 @@ class RevStatus(Interface):
                     yield dict(
                         action='status',
                         path=p,
-                        refds=ds.pathobj,
+                        refds=ds.path,
                         status='error',
                         message='path not underneath this dataset',
                         logger=lgr)
@@ -293,7 +293,7 @@ class RevStatus(Interface):
                 # there is only a single refds
                 yield dict(
                     path=text_type(qdspath),
-                    refds=ds.pathobj,
+                    refds=ds.path,
                     action='status',
                     status='error',
                     message=(

--- a/datalad_revolution/tests/test_create.py
+++ b/datalad_revolution/tests/test_create.py
@@ -77,8 +77,9 @@ def test_create_raises(path, outside_path):
     assert_in_results(
         ds.rev_create(outside_path, **raw),
         status='error',
-        message='path not associated with any dataset')
-
+        message=(
+            'dataset containing given paths is not underneath the reference '
+            'dataset %s: %s', ds, outside_path))
     # create a sub:
     ds.rev_create('sub')
     # fail when doing it again
@@ -124,8 +125,7 @@ def test_create_curdir(path, path2):
 @with_tempfile
 def test_create(path):
     ds = Dataset(path)
-    ds.rev_create(description="funny", native_metadata_type=['bim', 'bam', 'bum'],
-              shared_access='world')
+    ds.rev_create(description="funny", shared_access='world')
     ok_(ds.is_installed())
     ok_clean_git(ds.path, annex=True)
 
@@ -140,9 +140,6 @@ def test_create(path):
     # check datset ID
     eq_(ds.config.get_value('datalad.dataset', 'id'),
         ds.id)
-    assert_equal(
-        ds.config.get_value('datalad.metadata', 'nativetype'),
-        ('bim', 'bam', 'bum'))
 
 
 @with_tempfile
@@ -313,35 +310,6 @@ def test_create_withprocedure(path):
     ok_clean_git(path)
     ds.config.reload()
     eq_(ds.config['datalad.metadata.nativetype'], ('xmp', 'datacite'))
-
-
-# Skipping on Windows due to lack of MagicMime support:
-# https://github.com/datalad/datalad/pull/2770#issuecomment-415842284
-@known_failure_windows
-@with_tempfile(mkdir=True)
-def test_create_text_no_annex(path):
-    ds = create(path, text_no_annex=True)
-    ok_clean_git(path)
-    import re
-    ok_file_has_content(
-        _path_(path, '.gitattributes'),
-        content='\* annex\.largefiles=\(not\(mimetype=text/\*\)\)',
-        re_=True,
-        match=False,
-        flags=re.MULTILINE
-    )
-    # and check that it is really committing text files to git and binaries
-    # to annex
-    create_tree(path,
-        {
-            't': 'some text',
-            'b': ''  # empty file is not considered to be a text file
-                     # should we adjust the rule to consider only non empty files?
-        }
-    )
-    ds.rev_save(['t', 'b'])
-    ok_file_under_git(path, 't', annexed=False)
-    ok_file_under_git(path, 'b', annexed=True)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad_revolution/tests/test_create.py
+++ b/datalad_revolution/tests/test_create.py
@@ -27,19 +27,15 @@ from datalad.cmd import Runner
 
 from datalad.tests.utils import (
     with_tempfile,
-    create_tree,
     eq_,
     ok_,
     assert_not_in,
     assert_in,
     assert_raises,
-    assert_equal,
     assert_status,
     assert_in_results,
     ok_clean_git,
     with_tree,
-    ok_file_has_content,
-    ok_file_under_git,
     SkipTest,
 )
 

--- a/datalad_revolution/tests/test_create.py
+++ b/datalad_revolution/tests/test_create.py
@@ -120,6 +120,7 @@ def test_create_curdir(path, path2):
     ds = Dataset(path2)
     ok_(ds.is_installed())
     ok_clean_git(ds.path, annex=False)
+    ok_(op.exists(op.join(ds.path, '.noannex')))
 
 
 @with_tempfile

--- a/datalad_revolution/tests/test_create.py
+++ b/datalad_revolution/tests/test_create.py
@@ -126,7 +126,10 @@ def test_create_curdir(path, path2):
 @with_tempfile
 def test_create(path):
     ds = Dataset(path)
-    ds.rev_create(description="funny", shared_access='world')
+    ds.rev_create(
+        description="funny",
+        # custom git init option
+        opts=dict(shared='world'))
     ok_(ds.is_installed())
     ok_clean_git(ds.path, annex=True)
 

--- a/datalad_revolution/tests/test_create.py
+++ b/datalad_revolution/tests/test_create.py
@@ -61,8 +61,6 @@ def test_create_raises(path, outside_path):
     ds = Dataset(path)
     # incompatible arguments (annex only):
     assert_raises(ValueError, ds.create, no_annex=True, description='some')
-    assert_raises(ValueError, ds.create, no_annex=True, annex_opts=['some'])
-    assert_raises(ValueError, ds.create, no_annex=True, annex_init_opts=['some'])
 
     with open(op.join(path, "somefile.tst"), 'w') as f:
         f.write("some")
@@ -129,7 +127,7 @@ def test_create(path):
     ds.rev_create(
         description="funny",
         # custom git init option
-        opts=dict(shared='world'))
+        initopts=dict(shared='world'))
     ok_(ds.is_installed())
     ok_clean_git(ds.path, annex=True)
 


### PR DESCRIPTION
### Benchmarks

This version is a solid 30% faster than the one in -core. The benchmark is done using the Python API,
as extension commands are loaded late in the commandline, so there would be a bias.

```
# annex create (revolution)
>>> %timeit dl.rev_create('aaa' + str(random.random()))
1 loop, best of 3: 488 ms per loop

# annex create (core)
>>> %timeit dl.create('aaa' + str(random.random()))
1 loop, best of 3: 681 ms per loop

# git create (revolution)
>>> %timeit dl.rev_create('aaa' + str(random.random()), no_annex=True)
10 loops, best of 3: 137 ms per loop

# git create (core)
%timeit dl.create('aaa' + str(random.random()), no_annex=True)
1 loop, best of 3: 217 ms per loop
```