### PR TITLE
Improved `Repo.add` within `Repo.save`

### DIFF
--- a/datalad_revolution/annexrepo.py
+++ b/datalad_revolution/annexrepo.py
@@ -151,6 +151,110 @@ class RevolutionAnnexRepo(AnnexRepo, RevolutionGitRepo):
         return info
 
 
+    def _save_add(self, files, git=None, backend=None, options=None, jobs=None,
+            git_opts=None, annex_options=None, update=False):
+        """Like `add`, but returns a generator"""
+        if update and not git:
+            raise InsufficientArgumentsError("option 'update' requires 'git', too")
+
+        if git_opts:
+            # TODO: note that below we would use 'add with --dry-run
+            # so passed here options might need to be passed into it??
+            lgr.warning("add: git_options not yet implemented. Ignored.")
+
+        if annex_options:
+            lgr.warning("annex_options not yet implemented. Ignored.")
+
+        options = options[:] if options else []
+        # Note: As long as we support direct mode, one should not call
+        # super().add() directly. Once direct mode is gone, we might remove
+        # `git` parameter and call GitRepo's add() instead.
+
+        def _get_to_be_added_recs(paths):
+            """Try to collect what actually is going to be added
+
+            This is used for progress information
+            """
+
+            # Note: if a path involves a submodule in direct mode, while we
+            # are not in direct mode at current level, we might still fail.
+            # Hence the except clause is still needed. However, this is
+            # unlikely, since direct mode usually should be used only, if it
+            # was enforced by FS and/or OS and therefore concerns the entire
+            # hierarchy.
+            _git_options = ['--dry-run', '-N', '--ignore-missing']
+            try:
+                for r in super(AnnexRepo, self).add_(
+                        files, git_options=_git_options, update=update):
+                    yield r
+                    return
+            except CommandError as e:
+                if AnnexRepo._is_annex_work_tree_message(e.stderr):
+                    lgr.warning(
+                        "Known bug in direct mode."
+                        "We can't use --dry-run when there are submodules in "
+                        "direct mode, because the internal call to git status "
+                        "fails. To be resolved by using (Dataset's) status "
+                        "instead of a git-add --dry-run altogether.")
+                    # fake the return for now
+                    for r in self._process_git_get_output(
+                            linesep.join(["'{}'".format(f)
+                            for f in files])):
+                        yield r
+                        return
+                else:
+                    # unexpected failure
+                    raise e
+
+        # Theoretically we could have done for git as well, if it could have
+        # been batched
+        # Call git annex add for any to have full control of either to go
+        # to git or to annex
+        # 1. Figure out what actually will be added
+        to_be_added_recs = _get_to_be_added_recs(files)
+        # collect their sizes for the progressbar
+        expected_additions = {
+            rec['file']: self.get_file_size(rec['file'])
+            for rec in to_be_added_recs
+        }
+
+        # if None -- leave it to annex to decide
+        if git is not None:
+            options += [
+                '-c',
+                'annex.largefiles=%s' % (('anything', 'nothing')[int(git)])
+            ]
+            if git:
+                # to maintain behaviour similar to git
+                options += ['--include-dotfiles']
+
+        if git and update:
+            # explicitly use git-add with --update instead of git-annex-add
+            # TODO: This might still need some work, when --update AND files
+            # are specified!
+            try:
+                for r in super(AnnexRepo, self).add(
+                        files,
+                        git=True,
+                        git_options=git_options,
+                        update=update):
+                    yield r
+            finally:
+                pass
+
+        else:
+            for r in self._run_annex_command_json(
+                    'add',
+                    opts=options,
+                    files=files,
+                    backend=backend,
+                    expect_fail=True,
+                    jobs=jobs,
+                    expected_entries=expected_additions,
+                    expect_stderr=True):
+                yield r
+
+
 # remove deprecated methods from API
 for m in obsolete_methods + gitrepo_obsolete_methods:
     if hasattr(RevolutionAnnexRepo, m):

--- a/datalad_revolution/annexrepo.py
+++ b/datalad_revolution/annexrepo.py
@@ -151,73 +151,9 @@ class RevolutionAnnexRepo(AnnexRepo, RevolutionGitRepo):
         return info
 
 
-    def _save_add(self, files, git=None, backend=None, options=None, jobs=None,
-            git_opts=None, annex_options=None, update=False):
-        """Like `add`, but returns a generator"""
-        if update and not git:
-            raise InsufficientArgumentsError("option 'update' requires 'git', too")
-
-        if git_opts:
-            # TODO: note that below we would use 'add with --dry-run
-            # so passed here options might need to be passed into it??
-            lgr.warning("add: git_options not yet implemented. Ignored.")
-
-        if annex_options:
-            lgr.warning("annex_options not yet implemented. Ignored.")
-
-        options = options[:] if options else []
-        # Note: As long as we support direct mode, one should not call
-        # super().add() directly. Once direct mode is gone, we might remove
-        # `git` parameter and call GitRepo's add() instead.
-
-        def _get_to_be_added_recs(paths):
-            """Try to collect what actually is going to be added
-
-            This is used for progress information
-            """
-
-            # Note: if a path involves a submodule in direct mode, while we
-            # are not in direct mode at current level, we might still fail.
-            # Hence the except clause is still needed. However, this is
-            # unlikely, since direct mode usually should be used only, if it
-            # was enforced by FS and/or OS and therefore concerns the entire
-            # hierarchy.
-            _git_options = ['--dry-run', '-N', '--ignore-missing']
-            try:
-                for r in super(AnnexRepo, self).add_(
-                        files, git_options=_git_options, update=update):
-                    yield r
-                    return
-            except CommandError as e:
-                if AnnexRepo._is_annex_work_tree_message(e.stderr):
-                    lgr.warning(
-                        "Known bug in direct mode."
-                        "We can't use --dry-run when there are submodules in "
-                        "direct mode, because the internal call to git status "
-                        "fails. To be resolved by using (Dataset's) status "
-                        "instead of a git-add --dry-run altogether.")
-                    # fake the return for now
-                    for r in self._process_git_get_output(
-                            linesep.join(["'{}'".format(f)
-                            for f in files])):
-                        yield r
-                        return
-                else:
-                    # unexpected failure
-                    raise e
-
-        # Theoretically we could have done for git as well, if it could have
-        # been batched
-        # Call git annex add for any to have full control of either to go
-        # to git or to annex
-        # 1. Figure out what actually will be added
-        to_be_added_recs = _get_to_be_added_recs(files)
-        # collect their sizes for the progressbar
-        expected_additions = {
-            rec['file']: self.get_file_size(rec['file'])
-            for rec in to_be_added_recs
-        }
-
+    def _save_add(self, files, git=None, git_opts=None):
+        """Simple helper to add files in save()"""
+        options = []
         # if None -- leave it to annex to decide
         if git is not None:
             options += [
@@ -227,32 +163,18 @@ class RevolutionAnnexRepo(AnnexRepo, RevolutionGitRepo):
             if git:
                 # to maintain behaviour similar to git
                 options += ['--include-dotfiles']
-
-        if git and update:
-            # explicitly use git-add with --update instead of git-annex-add
-            # TODO: This might still need some work, when --update AND files
-            # are specified!
-            try:
-                for r in super(AnnexRepo, self).add(
-                        files,
-                        git=True,
-                        git_options=git_options,
-                        update=update):
-                    yield r
-            finally:
-                pass
-
-        else:
-            for r in self._run_annex_command_json(
-                    'add',
-                    opts=options,
-                    files=files,
-                    backend=backend,
-                    expect_fail=True,
-                    jobs=jobs,
-                    expected_entries=expected_additions,
-                    expect_stderr=True):
-                yield r
+        for r in self._run_annex_command_json(
+                'add',
+                opts=options,
+                files=files,
+                backend=None,
+                expect_fail=True,
+                # TODO
+                jobs=None,
+                # TODO
+                #expected_entries=expected_additions,
+                expect_stderr=True):
+            yield r
 
 
 # remove deprecated methods from API

--- a/datalad_revolution/annexrepo.py
+++ b/datalad_revolution/annexrepo.py
@@ -150,19 +150,23 @@ class RevolutionAnnexRepo(AnnexRepo, RevolutionGitRepo):
 
         return info
 
-
     def _save_add(self, files, git=None, git_opts=None):
         """Simple helper to add files in save()"""
-        options = []
+        # alter default behavior of git-annex by considering dotfiles
+        # too
+        # however, this helper is controlled by save() which itself
+        # operates on status() which itself honors .gitignore, so
+        # there is a standard mechanism that is uniform between Git
+        # Annex repos to decide on the behavior on a case-by-case
+        # basis
+        # TODO have a dedicated test for this
+        options = ['--include-dotfiles']
         # if None -- leave it to annex to decide
         if git is not None:
             options += [
                 '-c',
                 'annex.largefiles=%s' % (('anything', 'nothing')[int(git)])
             ]
-            if git:
-                # to maintain behaviour similar to git
-                options += ['--include-dotfiles']
         for r in self._run_annex_command_json(
                 'add',
                 opts=options,

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -589,19 +589,17 @@ class RevolutionGitRepo(GitRepo):
             # need to include .gitmodules in what needs saving
             status[self.pathobj.joinpath('.gitmodules')] = dict(
                 type='file', state='modified')
-        to_add = [
+        to_add = {
             # TODO remove pathobj stringification when add() can
             # handle it
-            str(f.relative_to(self.pathobj))
+            str(f.relative_to(self.pathobj)): props
             for f, props in iteritems(status)
-            if props.get('state', None) in ('modified', 'untracked')]
+            if props.get('state', None) in ('modified', 'untracked')}
         if to_add:
             lgr.debug(
                 '%i paths to add to %r %s',
                 len(to_add), self, to_add if len(to_add) < 10 else '')
             for r in self._save_add(
-                    # TODO actually pass the relevant status records
-                    # and make use of them in the helper!!
                     to_add,
                     git_opts=None,
                     **{k: kwargs[k] for k in kwargs
@@ -645,7 +643,7 @@ class RevolutionGitRepo(GitRepo):
         try:
             # without --verbose git 2.9.3  add does not return anything
             add_out = self._git_custom_command(
-                files,
+                list(files.keys()),
                 ['git', 'add'] + assure_list(git_opts) + ['--verbose']
             )
             # get all the entries

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -603,6 +603,7 @@ class RevolutionGitRepo(GitRepo):
                     **{k: kwargs[k] for k in kwargs
                        if k in (('git',) if hasattr(self, 'annexstatus')
                                 else tuple())}):
+                # TODO the helper can yield proper dicts right away
                 yield get_status_dict(
                     action=r.get('command', 'add'),
                     refds=self.pathobj,
@@ -636,7 +637,7 @@ class RevolutionGitRepo(GitRepo):
         # and post...
 
     def _save_add(self, files, git_opts=None):
-        """SImple helper to add files in save()"""
+        """Simple helper to add files in save()"""
         try:
             # without --verbose git 2.9.3  add does not return anything
             add_out = self._git_custom_command(

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -480,7 +480,11 @@ class RevolutionGitRepo(GitRepo):
         to_commit = [str(f.relative_to(self.pathobj))
                      for f, props in iteritems(status)]
         if to_commit:
-            self.commit(
+            # we directly call GitRepo.commit() to avoid a whole slew
+            # if direct-mode safeguards and workarounds in the AnnexRepo
+            # implementation (which also run an additional dry-run commit
+            GitRepo.commit(
+                self,
                 files=to_commit,
                 msg=message,
                 _datalad_msg=_datalad_msg,

--- a/datalad_revolution/tests/test_save.py
+++ b/datalad_revolution/tests/test_save.py
@@ -222,7 +222,6 @@ def test_symlinked_relpath(path):
     assert_repo_status(dspath)
 
 
-@known_failure_windows  # https://github.com/datalad/datalad/issues/2955
 @skip_wo_symlink_capability
 @with_tempfile(mkdir=True)
 def test_bf1886(path):
@@ -518,7 +517,6 @@ def test_relpath_add(path):
     assert_repo_status(ds.path)
 
 
-@known_failure_windows  # https://github.com/datalad/datalad/issues/2955
 @skip_wo_symlink_capability
 @with_tempfile()
 def test_bf2541(path):

--- a/datalad_revolution/tests/utils.py
+++ b/datalad_revolution/tests/utils.py
@@ -9,7 +9,7 @@ from functools import wraps
 from nose.plugins.attrib import attr
 
 from datalad.api import (
-    create,
+    rev_create as create,
 )
 
 from datalad_revolution.gitrepo import RevolutionGitRepo as GitRepo
@@ -155,10 +155,10 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
             op.join('subdir', 'file_dropped_clean')],
             check=False)
     # clean and proper subdatasets
-    ds.create('subds_clean')
-    ds.create(op.join('subdir', 'subds_clean'))
-    ds.create('subds_unavailable_clean')
-    ds.create(op.join('subdir', 'subds_unavailable_clean'))
+    ds.rev_create('subds_clean')
+    ds.rev_create(op.join('subdir', 'subds_clean'))
+    ds.rev_create('subds_unavailable_clean')
+    ds.rev_create(op.join('subdir', 'subds_unavailable_clean'))
     # uninstall some subdatasets (still clean)
     ds.uninstall([
         'subds_unavailable_clean',
@@ -166,13 +166,13 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
         check=False)
     assert_repo_status(ds.path)
     # make a dirty subdataset
-    ds.create('subds_modified')
-    ds.create(op.join('subds_modified', 'someds'))
-    ds.create(op.join('subds_modified', 'someds', 'dirtyds'))
+    ds.rev_create('subds_modified')
+    ds.rev_create(op.join('subds_modified', 'someds'))
+    ds.rev_create(op.join('subds_modified', 'someds', 'dirtyds'))
     # make a subdataset with additional commits
-    ds.create(op.join('subdir', 'subds_modified'))
+    ds.rev_create(op.join('subdir', 'subds_modified'))
     pdspath = op.join(ds.path, 'subdir', 'subds_modified', 'progressedds')
-    ds.create(pdspath)
+    ds.rev_create(pdspath)
     create_tree(
         pdspath,
         {'file_clean': 'file_ingit_clean'}


### PR DESCRIPTION
- [x] do not acquire info for progressbars when in the end no progressbar will be displayed (i.e. non-interactive sessions)
- [x] avoid dry-run call in `AnnexRepo.add` #3
- [x] avoid dry-run call in `AnnexRepo.commit` #3 
- [x] uniform handling of dotfiles between Git and Annex repos https://github.com/datalad/datalad/issues/1454
- [x] uniform handling of symlinks on Windows and operating systems https://github.com/datalad/datalad/issues/2955