### PR TITLE
ENH: Immitate git-annex and pass config opts into repo config on create

### DIFF
--- a/datalad_revolution/revcreate.py
+++ b/datalad_revolution/revcreate.py
@@ -369,7 +369,20 @@ class RevCreate(Interface):
         tbds.config.add(
             id_var,
             tbds.id if tbds.id is not None else uuid_id,
-            where='dataset')
+            where='dataset',
+            reload=False)
+
+        # make config overrides permanent in the repo config
+        # this is similar to what `annex init` does
+        # we are only doing this for config overrides and do not expose
+        # a dedicated argument, because it is sufficient for the cmdline
+        # and unnecessary for the Python API (there could simply be a
+        # subsequence ds.config.add() call)
+        for k, v in iteritems(tbds.config.overrides):
+            tbds.config.add(k, v, where='local', reload=False)
+
+        # all config manipulation is done -> fll reload
+        tbds.config.reload()
 
         # must use the repo.pathobj as this will have resolved symlinks
         add_to_git[tbds.repo.pathobj / '.datalad'] = {

--- a/datalad_revolution/tests/test_create.py
+++ b/datalad_revolution/tests/test_create.py
@@ -325,3 +325,16 @@ def test_create_fake_dates(path):
 
     eq_(ds.config.obtain("datalad.fake-dates-start") + 1,
         first_commit.committed_date)
+
+
+@with_tempfile(mkdir=True)
+def test_cfg_passthrough(path):
+    runner = Runner()
+    _ = runner.run(
+        ['datalad',
+         '-c', 'annex.tune.objecthash1=true',
+         '-c', 'annex.tune.objecthashlower=true',
+         'rev-create', path])
+    ds = Dataset(path)
+    eq_(ds.config.get('annex.tune.objecthash1', None), 'true')
+    eq_(ds.config.get('annex.tune.objecthashlower', None), 'true')


### PR DESCRIPTION
This adresses https://github.com/datalad/datalad/issues/2851

```
% datalad -c annex.tune.objecthash1=true -c annex.tune.objecthashlower=true rev-create t5
[INFO   ] Creating a new annex repo at /tmp/t5
create(ok): /tmp/t5 (dataset)
(datalad3-dev) mih@meiner /tmp % cat t5/.git/config
[core]
        repositoryformatversion = 0
        filemode = true
        bare = false
        logallrefupdates = true
[annex]
        uuid = 02cbee48-c663-4dbd-bbfe-0a4f14051bcd
        version = 5
        backends = MD5E
[annex "tune"]
        objecthash1 = true
        objecthashlower = true
```