### PR TITLE
Fix #33

### DIFF
--- a/datalad_revolution/tests/test_save.py
+++ b/datalad_revolution/tests/test_save.py
@@ -570,6 +570,6 @@ def test_partial_unlocked(path):
     # but now a change in the attributes
     ds.unlock('culprit.txt')
     ds.repo.set_gitattributes([
-        ('*', {'annex.largefiles': '(not(mimetype=text/*'})])
+        ('*', {'annex.largefiles': 'nothing'})])
     ds.rev_save()
     assert_repo_status(ds.path)


### PR DESCRIPTION
It turns out that in order to cause this issue it needs a change in the largefiles config. Any other combination of unlock and modification in git or annex seems to work just fine.

And it doesn't matter whether the change in `.gitattributes` is already commited or not.