### PR TITLE
This brings `rev-diff`

### DIFF
--- a/datalad_revolution/__init__.py
+++ b/datalad_revolution/__init__.py
@@ -35,6 +35,12 @@ command_suite = (
             'rev_status'
         ),
         (
+            'datalad_revolution.revdiff',
+            'RevDiff',
+            'rev-diff',
+            'rev_diff'
+        ),
+        (
             'datalad_revolution.revrun',
             'RevRun',
             'rev-run',

--- a/datalad_revolution/annexrepo.py
+++ b/datalad_revolution/annexrepo.py
@@ -70,7 +70,7 @@ class RevolutionAnnexRepo(AnnexRepo, RevolutionGitRepo):
 
     def get_content_annexinfo(
             self, paths=None, init='git', ref=None, eval_availability=False,
-            **kwargs):
+            key_prefix='', **kwargs):
         """
         Parameters
         ----------
@@ -131,8 +131,12 @@ class RevolutionAnnexRepo(AnnexRepo, RevolutionGitRepo):
             opts = [str(p) for p in paths] if paths else ['--include', '*']
         for j in self._run_annex_command_json(cmd, opts=opts):
             path = self.pathobj.joinpath(ut.PurePosixPath(j['file']))
-            rec = info.get(path, {})
-            rec.update({k: j[k] for k in j if k != 'file'})
+            rec = info.get(path, None)
+            if init is not None and rec is None:
+                # init constraint knows nothing about this path -> skip
+                continue
+            rec.update({'{}{}'.format(key_prefix, k): j[k]
+                       for k in j if k != 'file'})
             info[path] = rec
             # TODO make annex availability checks optional and move in here
             if not eval_availability:

--- a/datalad_revolution/annexrepo.py
+++ b/datalad_revolution/annexrepo.py
@@ -152,13 +152,13 @@ class RevolutionAnnexRepo(AnnexRepo, RevolutionGitRepo):
             init=self.get_content_annexinfo(
                 paths=paths,
                 ref='HEAD',
-                eval_availability=False))
+                eval_availability=False,
+                init=self.status(
+                    paths=paths,
+                    ignore_submodules='other')
+            )
+        )
         self._mark_content_availability(info)
-        for f, r in iteritems(self.status(paths=paths)):
-            inf = info.get(f, {})
-            inf.update(r)
-            info[f] = inf
-
         return info
 
     def _save_add(self, files, git=None, git_opts=None):

--- a/datalad_revolution/dataset.py
+++ b/datalad_revolution/dataset.py
@@ -175,6 +175,14 @@ def resolve_path(path, ds=None):
     considered relative to the location of the dataset. If no dataset is
     provided, the current working directory is used.
 
+    Note however, that this function is not able to resolve arbitrarily
+    obfuscated path specifications. All operations are purely lexical, and no
+    actual path resolution against the filesystem content is performed.
+    Consequently, common relative path arguments like '../something' (relative
+    to PWD) can be handled properly, but things like 'down/../under' cannot, as
+    resolving this path properly depends on the actual target of any
+    (potential) symlink leading up to '..'.
+
     Parameters
     ----------
     path : str or PathLike
@@ -204,8 +212,37 @@ def resolve_path(path, ds=None):
     # make sure we return an absolute path, but without actually
     # resolving anything
     if not path.is_absolute():
-        # not using ut.Path.cwd(), because it is symlinks resolved!!
-        path = ut.Path(getpwd()) / path
+        # in general it is almost impossible to use resolve() when
+        # we can have symlinks in the root path of a dataset
+        # (that we don't want to resolve here), symlinks to annex'ed
+        # files (that we never want to resolve), and other within-repo
+        # symlinks that we (sometimes) want to resolve (i.e. symlinked
+        # paths for addressing content vs adding content)
+        # CONCEPT: do the minimal thing to catch most real-world inputs
+        # ASSUMPTION: the only sane relative path input that needs
+        # handling and can be handled are upward references like
+        # '../../some/that', wherease stuff like 'down/../someotherdown'
+        # are intellectual excercises
+        # ALGORITHM: match any number of leading '..' path components
+        # and shorten the PWD by that number
+        # NOT using ut.Path.cwd(), because it has symlinks resolved!!
+        pwd_parts = ut.Path(getpwd()).parts
+        path_parts = path.parts
+        leading_parents = 0
+        for p in path.parts:
+            if p == op.pardir:
+                leading_parents += 1
+                path_parts = path_parts[1:]
+            elif p == op.curdir:
+                # we want to discard that, but without stripping
+                # a corresponding parent
+                path_parts = path_parts[1:]
+            else:
+                break
+        path = ut.Path(
+            op.join(
+                *(pwd_parts[:-leading_parents if leading_parents else None]
+                  + path_parts)))
     # note that we will not "normpath()" the result, check the
     # pathlib docs for why this is the only sane choice in the
     # face of the possibility of symlinks in the path

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -393,8 +393,10 @@ class RevolutionGitRepo(GitRepo):
                     # cases
                     type=to_state_r['type'],
                 )
-            if props['state'] in ('clean', 'added'):
+            if props['state'] in ('clean', 'added', 'modified'):
                 props['gitshasum'] = to_state_r['gitshasum']
+            if props['state'] in ('clean', 'modified', 'deleted'):
+                props['prev_gitshasum'] = from_state[f]['gitshasum']
             status[f] = props
 
         for f, from_state_r in iteritems(from_state):

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -226,7 +226,12 @@ class RevolutionGitRepo(GitRepo):
             # -> only report on paths that were actually queried
             paths = {self.pathobj / p for p in paths}
             info = {k: v for k, v in iteritems(info)
-                    if k in paths or v.get('type', None) != 'dataset'}
+                    # a non-dataset path
+                    if v.get('type', None) != 'dataset'
+                    # this very path was queried
+                    or k in paths
+                    # the entire dataset was queried (i.e. ['.'])
+                    or self.pathobj in paths}
         return info
 
     def status(self, paths=None, untracked='all', ignore_submodules='no'):

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -381,8 +381,6 @@ class RevolutionGitRepo(GitRepo):
             else:
                 # change in git record, or on disk
                 props = dict(
-                    # TODO is 'modified' enough, should be report typechange?
-                    # often this will be a pointless detail, though...
                     # TODO we could have a new file that is already staged
                     # but had subsequent modifications done to it that are
                     # unstaged. Such file would presently show up as 'added'

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -80,11 +80,18 @@ class RevolutionGitRepo(GitRepo):
 
         This is simplified front-end for `git ls-files/tree`.
 
+        Both commands differ in their behavior when queried about subdataset
+        paths. ls-files will not report anything, ls-tree will report on the
+        subdataset record. This function uniformly follows the behavior of
+        ls-tree (report on the respective subdataset mount).
+
         Parameters
         ----------
-        paths : list
-          Specific paths to query info for. In none are given, info is
-          reported for all content.
+        paths : list(patlib.PurePath)
+          Specific paths, relative to the (resolved repository root, to query
+          info for. Paths must be normed to match the reporting done by Git,
+          i.e. no parent dir components (ala "some/../this").
+          If none are given, info is reported for all content.
         ref : gitref or None
           If given, content information is retrieved for this Git reference
           (via ls-tree), otherwise content information is produced for the
@@ -157,7 +164,11 @@ class RevolutionGitRepo(GitRepo):
 
         try:
             stdout, stderr = self._git_custom_command(
-                [str(f) for f in paths] if paths else [],
+                # specifically always ask for a full report and
+                # filter out matching path later on to
+                # homogenize wrt subdataset content paths across
+                # ls-files and ls-tree
+                None,
                 cmd,
                 log_stderr=True,
                 log_stdout=True,
@@ -207,6 +218,22 @@ class RevolutionGitRepo(GitRepo):
                     # on the particular mode annex is in
                     inf['type'] = 'file'
 
+            # the function assumes that any `path` is a relative path lib
+            # instance if there were path constraints given, we need to reject
+            # paths now
+            # reject anything that is:
+            # - not a direct match with a constraint
+            # - has no constraint as a parent
+            #   (relevant to find matches of regular files in a repository)
+            # - is not a parent of a constraint
+            #   (relevant for finding the matching subds entry for
+            #    subds-content paths)
+            if paths \
+                and not any(
+                    path == c or path in c.parents or c in path.parents
+                    for c in paths):
+                continue
+
             # join item path with repo path to get a universally useful
             # path representation with auto-conversion and tons of other
             # stuff
@@ -217,21 +244,6 @@ class RevolutionGitRepo(GitRepo):
                     else 'directory' if path.is_dir() else 'file'
             info[path] = inf
 
-        # final loop to filter out reports on paths (that where given)
-        # that do not belong to this repo (which status() would turn into
-        if paths is not None and ref is not None:
-            # dedicated paths were queried, but ls-tree would respond with
-            # an entry for each path that is actually contained in a
-            # submodule with a report on the respective subdataset path
-            # -> only report on paths that were actually queried
-            paths = {self.pathobj / p for p in paths}
-            info = {k: v for k, v in iteritems(info)
-                    # a non-dataset path
-                    if v.get('type', None) != 'dataset'
-                    # this very path was queried
-                    or k in paths
-                    # the entire dataset was queried (i.e. ['.'])
-                    or self.pathobj in paths}
         return info
 
     def status(self, paths=None, untracked='all', ignore_submodules='no'):
@@ -241,7 +253,9 @@ class RevolutionGitRepo(GitRepo):
         ----------
         paths : list or None
           If given, limits the query to the specified paths. To query all
-          paths specify `None`, not an empty list.
+          paths specify `None`, not an empty list. If a query path points
+          into a subdataset, a report is made on the subdataset record
+          within the queried dataset only (no recursion).
         untracked : {'no', 'normal', 'all'}
           If and how untracked content is reported when no `ref` was given:
           'no': no untracked files are reported; 'normal': untracked files
@@ -317,6 +331,16 @@ class RevolutionGitRepo(GitRepo):
 
         if _cache is None:
             _cache = {}
+
+        if paths:
+            # at this point we must normalize paths to the form that
+            # Git would report them, to easy matching later on
+            paths = [ut.Path(p) for p in paths]
+            paths = [
+                p.relative_to(self.pathobj) if p.is_absolute() else p
+                for p in paths
+            ]
+
         # TODO report more info from get_content_info() calls in return
         # value, those are cheap and possibly useful to a consumer
         status = OrderedDict()
@@ -615,7 +639,7 @@ class RevolutionGitRepo(GitRepo):
         to_add_submodules = [sm for sm, sm_props in iteritems(
             self.get_content_info(
                 # get content info for any untracked directory
-                [f for f, props in iteritems(status)
+                [f.relative_to(self.pathobj) for f, props in iteritems(status)
                  if props.get('state', None) == 'untracked' and
                  props.get('type', None) == 'directory'],
                 ref=None,

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -138,6 +138,12 @@ class RevolutionGitRepo(GitRepo):
             '120000': 'symlink',
             '160000': 'dataset',
         }
+        if paths:
+            # path matching will happen against what Git reports
+            # and Git always reports POSIX paths
+            # any incoming path has to be relative already, so we can simply
+            # convert unconditionally
+            paths = [ut.PurePosixPath(p) for p in paths]
 
         # this will not work in direct mode, but everything else should be
         # just fine

--- a/datalad_revolution/revdiff.py
+++ b/datalad_revolution/revdiff.py
@@ -1,0 +1,128 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Report differences between two states of a dataset (hierarchy)"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+import os.path as op
+from six import (
+    iteritems,
+    text_type,
+)
+from datalad.utils import (
+    assure_list,
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.utils import eval_results
+
+from datalad_revolution.dataset import (
+    RevolutionDataset as Dataset,
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+    resolve_path,
+    path_under_dataset,
+    get_dataset_root,
+)
+import datalad_revolution.utils as ut
+from datalad_revolution.revstatus import (
+    RevStatus,
+)
+
+from datalad.support.constraints import EnsureNone
+from datalad.support.constraints import EnsureStr
+from datalad.support.param import Parameter
+
+lgr = logging.getLogger('datalad.revolution.diff')
+
+
+@build_doc
+class RevDiff(Interface):
+    """
+    """
+    # make the custom renderer the default one, as the global default renderer
+    # does not yield meaningful output for this command
+    result_renderer = 'tailored'
+
+    _params_ = dict(
+        RevStatus._params_,
+        fr=Parameter(
+            args=("-f", "--from",),
+            dest='fr',
+            metavar="REVISION",
+            doc="""original state to compare to, as given by any identifier
+            that Git understands.""",
+            nargs=1,
+            constraints=EnsureStr()),
+        to=Parameter(
+            args=("-t", "--to",),
+            metavar="REVISION",
+            doc="""state to compare against the original state, as given by
+            any identifier that Git understands. If none is specified,
+            the state of the worktree will be used compared.""",
+            nargs=1,
+            constraints=EnsureStr() | EnsureNone()),
+    )
+
+    @staticmethod
+    @datasetmethod(name='rev_diff')
+    @eval_results
+    def __call__(
+            fr='HEAD',
+            to=None,
+            path=None,
+            dataset=None,
+            annex=None,
+            untracked='normal',
+            recursive=False,
+            recursion_limit=None):
+        ds = require_dataset(
+            dataset, check_installed=True, purpose='difference reporting')
+
+        # convert cmdline args into plain labels
+        if isinstance(fr, list):
+            fr = fr[0]
+        if isinstance(to, list):
+            to = to[0]
+
+        # TODO we cannot really perform any sorting of paths into subdatasets
+        # or rejecting paths based on the state of the filesystem, as
+        # we need to be able to compare with states that are not represented
+        # in the worktree (anymore)
+
+        # cache to help avoid duplicate status queries
+        content_info_cache = {}
+        # TODO loop over results and dive into subdatasets with --recursive
+        # do this inside the loop to go depth-first
+        # https://github.com/datalad/datalad/issues/2161
+        repo_path = ds.repo.pathobj
+        for path, props in iteritems(ds.repo.diffstatus(
+                fr,
+                to,
+                paths=[] if not path else assure_list(path),
+                untracked=untracked,
+                ignore_submodules='other',
+                _cache=content_info_cache)):
+            cpath = ds.pathobj / path.relative_to(repo_path)
+            yield dict(
+                props,
+                path=str(cpath),
+                # report the dataset path rather than the repo path to avoid
+                # realpath/symlink issues
+                parentds=ds.path,
+                # TODO factor out the remaining ones
+                refds=ds.path,
+                action='diff',
+                status='ok',
+            )

--- a/datalad_revolution/revdiff.py
+++ b/datalad_revolution/revdiff.py
@@ -61,12 +61,6 @@ _common_diffstatus_params = dict(
         no dataset is given, an attempt is made to identify the dataset
         based on the current working directory""",
         constraints=EnsureDataset() | EnsureNone()),
-    path=Parameter(
-        args=("path",),
-        metavar="PATH",
-        doc="""path to be evaluated""",
-        nargs="*",
-        constraints=EnsureStr() | EnsureNone()),
     annex=Parameter(
         args=('--annex',),
         metavar='MODE',
@@ -98,7 +92,21 @@ _common_diffstatus_params = dict(
 
 @build_doc
 class RevDiff(Interface):
-    """
+    """Report differences between two states of a dataset (hierarchy)
+
+    The two to-be-compared states are given via to --from and --to options.
+    These state identifiers are evaluated in the context of the (specified
+    or detected) dataset. In case of a recursive report on a dataset
+    hierarchy corresponding state pairs for any subdataset are determined
+    from the subdataset record in the respective superdataset. Only changes
+    recorded in a subdataset between these two states are reported, and so on.
+
+    Any paths given as additional arguments will be used to constrain the
+    difference report. As with Git's diff, it will not result in an error when
+    a path is specified that does not exist on the filesystem.
+
+    Reports are very similar to those of the `rev-status` command, with the
+    distinguished content types and states being identical.
     """
     # make the custom renderer the default one, as the global default renderer
     # does not yield meaningful output for this command
@@ -106,6 +114,12 @@ class RevDiff(Interface):
 
     _params_ = dict(
         _common_diffstatus_params,
+        path=Parameter(
+            args=("path",),
+            metavar="PATH",
+            doc="""path to contrain the report to""",
+            nargs="*",
+            constraints=EnsureStr() | EnsureNone()),
         fr=Parameter(
             args=("-f", "--from",),
             dest='fr',

--- a/datalad_revolution/revdiff.py
+++ b/datalad_revolution/revdiff.py
@@ -19,7 +19,6 @@ from six import (
     text_type,
 )
 from collections import OrderedDict
-from datalad.dochelpers import exc_str
 from datalad.utils import (
     assure_list,
 )
@@ -28,8 +27,12 @@ from datalad.interface.base import (
     build_doc,
 )
 from datalad.interface.utils import eval_results
+from datalad.interface.common_opts import (
+    recursion_limit,
+    recursion_flag,
+)
 
-from datalad_revolution.dataset import (
+from .dataset import (
     RevolutionDataset as Dataset,
     EnsureDataset,
     datasetmethod,
@@ -39,16 +42,58 @@ from datalad_revolution.dataset import (
     get_dataset_root,
 )
 import datalad_revolution.utils as ut
-from datalad_revolution.revstatus import (
-    RevStatus,
-)
 
-from datalad.support.constraints import EnsureNone
-from datalad.support.constraints import EnsureStr
+from datalad.support.constraints import (
+    EnsureNone,
+    EnsureStr,
+    EnsureChoice,
+)
 from datalad.support.param import Parameter
 from datalad.consts import PRE_INIT_COMMIT_SHA
 
 lgr = logging.getLogger('datalad.revolution.diff')
+
+
+_common_diffstatus_params = dict(
+    dataset=Parameter(
+        args=("-d", "--dataset"),
+        doc="""specify the dataset to query.  If
+        no dataset is given, an attempt is made to identify the dataset
+        based on the current working directory""",
+        constraints=EnsureDataset() | EnsureNone()),
+    path=Parameter(
+        args=("path",),
+        metavar="PATH",
+        doc="""path to be evaluated""",
+        nargs="*",
+        constraints=EnsureStr() | EnsureNone()),
+    annex=Parameter(
+        args=('--annex',),
+        metavar='MODE',
+        constraints=EnsureChoice(None, 'basic', 'availability', 'all'),
+        doc="""Switch whether to include information on the annex
+        content of individual files in the status report, such as
+        recorded file size. By default no annex information is reported
+        (faster). Three report modes are available: basic information
+        like file size and key name ('basic'); additionally test whether
+        file content is present in the local annex ('availability';
+        requires one or two additional file system stat calls, but does
+        not call git-annex), this will add the result properties
+        'has_content' (boolean flag) and 'objloc' (absolute path to an
+        existing annex object file); or 'all' which will report all
+        available information (presently identical to 'availability').
+        """),
+    untracked=Parameter(
+        args=('--untracked',),
+        metavar='MODE',
+        constraints=EnsureChoice('no', 'normal', 'all'),
+        doc="""If and how untracked content is reported when comparing
+        a revision to the state of the work tree. 'no': no untracked
+        content is reported; 'normal': untracked files and entire
+        untracked directories are reported as such; 'all': report
+        individual files even in fully untracked directories."""),
+    recursive=recursion_flag,
+    recursion_limit=recursion_limit)
 
 
 @build_doc
@@ -60,7 +105,7 @@ class RevDiff(Interface):
     result_renderer = 'tailored'
 
     _params_ = dict(
-        RevStatus._params_,
+        _common_diffstatus_params,
         fr=Parameter(
             args=("-f", "--from",),
             dest='fr',
@@ -100,67 +145,18 @@ class RevDiff(Interface):
         if isinstance(to, list):
             to = to[0]
 
-        # we cannot really perform any sorting of paths into subdatasets
-        # or rejecting paths based on the state of the filesystem, as
-        # we need to be able to compare with states that are not represented
-        # in the worktree (anymore)
-        if path:
-            ps = []
-            # sort any path argument into the respective subdatasets
-            for p in sorted(assure_list(path)):
-                # it is important to capture the exact form of the
-                # given path argument, before any normalization happens
-                # distinguish rsync-link syntax to identify
-                # a dataset as whole (e.g. 'ds') vs its
-                # content (e.g. 'ds/')
-                # special case is the root dataset, always report its content
-                # changes
-                orig_path = str(p)
-                resolved_path = resolve_path(p, dataset)
-                p = \
-                    resolved_path, \
-                    orig_path.endswith(op.sep) or resolved_path == ds.pathobj
-                root = get_dataset_root(str(p[0]))
-                if root is None:
-                    # no root, not possibly underneath the refds
-                    yield dict(
-                        action='status',
-                        path=str(p[0]),
-                        refds=ds.path,
-                        status='error',
-                        message='path not underneath this dataset',
-                        logger=lgr)
-                    continue
-                ps.append(p)
-            path = ps
-
-        # TODO we might want to move away from the single-pass+immediate-yield
-        # paradigm for this command. If we gather all information first, we
-        # could do post-processing and detect when a file (same gitsha, or same
-        # key) was copied/moved from another dataset. Another command (e.g.
-        # rev-save) could act on this information and also move/copy
-        # availability information or at least enhance the respective commit
-        # message with cross-dataset provenance info
-
-        # cache to help avoid duplicate status queries
-        content_info_cache = {}
-        for res in _diff_ds(
-                ds,
-                fr,
-                to,
-                recursion_limit
-                if recursion_limit is not None and recursive
-                else -1 if recursive else 0,
-                # TODO recode paths to repo path reference
-                origpaths=None if not path else OrderedDict(path),
+        for r in _diff_cmd(
+                ds=ds,
+                dataset=dataset,
+                fr=fr,
+                to=to,
+                constant_refs=False,
+                path=path,
+                annex=annex,
                 untracked=untracked,
-                cache=content_info_cache):
-            res.update(
-                refds=ds.path,
-                logger=lgr,
-                action='diff',
-            )
-            yield res
+                recursive=recursive,
+                recursion_limit=recursion_limit):
+            yield r
 
     @staticmethod
     def custom_result_renderer(res, **kwargs):  # pragma: no cover
@@ -197,7 +193,102 @@ class RevDiff(Interface):
                 ut.ac.color_word(type_, ut.ac.MAGENTA) if type_ else '')))
 
 
-def _diff_ds(ds, fr, to, recursion_level, origpaths, untracked, cache):
+def _diff_cmd(
+        ds,
+        dataset,
+        fr,
+        to,
+        constant_refs,
+        path=None,
+        annex=None,
+        untracked='normal',
+        recursive=False,
+        recursion_limit=None):
+    """Internal helper to actually run the command"""
+    # we cannot really perform any sorting of paths into subdatasets
+    # or rejecting paths based on the state of the filesystem, as
+    # we need to be able to compare with states that are not represented
+    # in the worktree (anymore)
+    if path:
+        ps = []
+        # sort any path argument into the respective subdatasets
+        for p in sorted(assure_list(path)):
+            # it is important to capture the exact form of the
+            # given path argument, before any normalization happens
+            # distinguish rsync-link syntax to identify
+            # a dataset as whole (e.g. 'ds') vs its
+            # content (e.g. 'ds/')
+            # special case is the root dataset, always report its content
+            # changes
+            orig_path = str(p)
+            resolved_path = resolve_path(p, dataset)
+            p = \
+                resolved_path, \
+                orig_path.endswith(op.sep) or resolved_path == ds.pathobj
+            str_path = text_type(p[0])
+            root = get_dataset_root(str_path)
+            if root is None:
+                # no root, not possibly underneath the refds
+                yield dict(
+                    action='status',
+                    path=str_path,
+                    refds=ds.path,
+                    status='error',
+                    message='path not underneath this dataset',
+                    logger=lgr)
+                continue
+            if path_under_dataset(ds, str_path) is None:
+                # nothing we support handling any further
+                # there is only a single refds
+                yield dict(
+                    path=str_path,
+                    refds=ds.path,
+                    action='diff',
+                    status='error',
+                    message=(
+                        "dataset containing given paths is not underneath "
+                        "the reference dataset %s: %s",
+                        ds, str_path),
+                    logger=lgr,
+                )
+                continue
+
+            ps.append(p)
+        path = ps
+
+    # TODO we might want to move away from the single-pass+immediate-yield
+    # paradigm for this command. If we gather all information first, we
+    # could do post-processing and detect when a file (same gitsha, or same
+    # key) was copied/moved from another dataset. Another command (e.g.
+    # rev-save) could act on this information and also move/copy
+    # availability information or at least enhance the respective commit
+    # message with cross-dataset provenance info
+
+    # cache to help avoid duplicate status queries
+    content_info_cache = {}
+    for res in _diff_ds(
+            ds,
+            fr,
+            to,
+            constant_refs,
+            recursion_limit
+            if recursion_limit is not None and recursive
+            else -1 if recursive else 0,
+            # TODO recode paths to repo path reference
+            origpaths=None if not path else OrderedDict(path),
+            untracked=untracked,
+            annexinfo=annex,
+            cache=content_info_cache):
+        res.update(
+            refds=ds.path,
+            logger=lgr,
+            action='diff',
+        )
+        yield res
+
+
+def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
+             annexinfo, cache):
     repo_path = ds.repo.pathobj
     # filter and normalize paths that match this dataset before passing them
     # onto the low-level query method
@@ -228,6 +319,21 @@ def _diff_ds(ds, fr, to, recursion_level, origpaths, untracked, cache):
             )
             return
 
+    if annexinfo and hasattr(ds.repo, 'get_content_annexinfo'):
+        # this will ammend `status`
+        ds.repo.get_content_annexinfo(
+            paths=paths if paths else None,
+            init=diff_state,
+            eval_availability=annexinfo in ('availability', 'all'),
+            ref=to)
+        if fr != to:
+            ds.repo.get_content_annexinfo(
+                paths=paths if paths else None,
+                init=diff_state,
+                eval_availability=annexinfo in ('availability', 'all'),
+                ref=fr,
+                key_prefix="prev_")
+
     for path, props in iteritems(diff_state):
         pathinds = str(ds.pathobj / path.relative_to(repo_path))
         yield dict(
@@ -252,15 +358,20 @@ def _diff_ds(ds, fr, to, recursion_level, origpaths, untracked, cache):
                 for r in _diff_ds(
                         subds,
                         # from before time or from the reported state
-                        PRE_INIT_COMMIT_SHA
+                        fr if constant_refs
+                        else PRE_INIT_COMMIT_SHA
                         if subds_state == 'added'
                         else props['prev_gitshasum'],
                         # to the last recorded state, or the worktree
-                        None if to is None else props['gitshasum'],
+                        None if to is None
+                        else to if constant_refs
+                        else props['gitshasum'],
+                        constant_refs,
                         # subtract on level on the way down
                         recursion_level=recursion_level - 1,
                         origpaths=origpaths,
                         untracked=untracked,
+                        annexinfo=annexinfo,
                         cache=cache):
                     yield r
             else:

--- a/datalad_revolution/revdiff.py
+++ b/datalad_revolution/revdiff.py
@@ -175,14 +175,8 @@ class RevDiff(Interface):
         path = res['path'] if refds is None \
             else str(ut.Path(res['path']).relative_to(refds))
         type_ = res.get('type', res.get('type_src', ''))
-        max_len = len('modified (staged)')
+        max_len = len('untracked')
         state = res['state']
-        if state == 'modified' \
-                and kwargs.get('to', None) is None \
-                and 'gitshasum' in res \
-                and 'prev_gitshasum' in res \
-                and res['gitshasum'] != res['prev_gitshasum']:
-            state = 'modified (staged)'
         ui.message('{fill}{state}: {path}{type_}'.format(
             fill=' ' * max(0, max_len - len(state)),
             state=ut.ac.color_word(

--- a/datalad_revolution/revdiff.py
+++ b/datalad_revolution/revdiff.py
@@ -289,6 +289,11 @@ def _diff_cmd(
 
 def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
              annexinfo, cache):
+    if not ds.repo:
+        # asked to query a subdataset that is not available
+        lgr.debug("Skip diff of unavailable subdataset: %s", ds)
+        return
+
     repo_path = ds.repo.pathobj
     # filter and normalize paths that match this dataset before passing them
     # onto the low-level query method

--- a/datalad_revolution/revdiff.py
+++ b/datalad_revolution/revdiff.py
@@ -120,7 +120,7 @@ class RevDiff(Interface):
             diff_state = ds.repo.diffstatus(
                 fr,
                 to,
-                paths=[] if not path else assure_list(path),
+                paths=None if not path else assure_list(path),
                 untracked=untracked,
                 ignore_submodules='other',
                 _cache=content_info_cache)

--- a/datalad_revolution/revdiff.py
+++ b/datalad_revolution/revdiff.py
@@ -102,6 +102,14 @@ class RevDiff(Interface):
         # we need to be able to compare with states that are not represented
         # in the worktree (anymore)
 
+        # TODO we might want to move away from the single-pass+immediate-yield
+        # paradigm for this command. If we gather all information first, we
+        # could do post-processing and detect when a file (same gitsha, or same
+        # key) was copied/moved from another dataset. Another command (e.g.
+        # rev-save) could act on this information and also move/copy
+        # availability information or at least enhance the respective commit
+        # message with cross-dataset provenance info
+
         # cache to help avoid duplicate status queries
         content_info_cache = {}
         # TODO loop over results and dive into subdatasets with --recursive

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -12,7 +12,6 @@ __docformat__ = 'restructuredtext'
 
 
 import logging
-import os
 import os.path as op
 from six import (
     iteritems,
@@ -28,14 +27,9 @@ from datalad.interface.base import (
     build_doc,
 )
 from datalad.interface.utils import eval_results
-from datalad.interface.common_opts import (
-    recursion_limit,
-    recursion_flag,
-)
 
 from .dataset import (
     RevolutionDataset as Dataset,
-    EnsureDataset,
     datasetmethod,
     require_dataset,
     resolve_path,
@@ -44,10 +38,10 @@ from .dataset import (
 )
 from . import utils as ut
 
-from datalad.support.constraints import EnsureNone
-from datalad.support.constraints import EnsureStr
-from datalad.support.constraints import EnsureChoice
-from datalad.support.param import Parameter
+from datalad_revolution.revdiff import (
+    RevDiff,
+    _common_diffstatus_params,
+)
 
 lgr = logging.getLogger('datalad.revolution.status')
 
@@ -171,46 +165,7 @@ class RevStatus(Interface):
     # does not yield meaningful output for this command
     result_renderer = 'tailored'
 
-    _params_ = dict(
-        dataset=Parameter(
-            args=("-d", "--dataset"),
-            doc="""specify the dataset to query.  If
-            no dataset is given, an attempt is made to identify the dataset
-            based on the current working directory""",
-            constraints=EnsureDataset() | EnsureNone()),
-        path=Parameter(
-            args=("path",),
-            metavar="PATH",
-            doc="""path to be evaluated""",
-            nargs="*",
-            constraints=EnsureStr() | EnsureNone()),
-        annex=Parameter(
-            args=('--annex',),
-            metavar='MODE',
-            constraints=EnsureChoice(None, 'basic', 'availability', 'all'),
-            doc="""Switch whether to include information on the annex
-            content of individual files in the status report, such as
-            recorded file size. By default no annex information is reported
-            (faster). Three report modes are available: basic information
-            like file size and key name ('basic'); additionally test whether
-            file content is present in the local annex ('availability';
-            requires one or two additional file system stat calls, but does
-            not call git-annex), this will add the result properties
-            'has_content' (boolean flag) and 'objloc' (absolute path to an
-            existing annex object file); or 'all' which will report all
-            available information (presently identical to 'availability').
-            """),
-        untracked=Parameter(
-            args=('--untracked',),
-            metavar='MODE',
-            constraints=EnsureChoice('no', 'normal', 'all'),
-            doc="""If and how untracked content is reported when comparing
-            a revision to the state of the work tree. 'no': no untracked
-            content is reported; 'normal': untracked files and entire
-            untracked directories are reported as such; 'all': report
-            individual files even in fully untracked directories."""),
-        recursive=recursion_flag,
-        recursion_limit=recursion_limit)
+    _params_ = _common_diffstatus_params
 
     @staticmethod
     @datasetmethod(name='rev_status')
@@ -325,33 +280,7 @@ class RevStatus(Interface):
 
     @staticmethod
     def custom_result_renderer(res, **kwargs):  # pragma: no cover
-        if not res['status'] == 'ok' or res.get('state', None) == 'clean':
-            # logging reported already
-            return
-        from datalad.ui import ui
-        # when to render relative paths:
-        #  1) if a dataset arg was given
-        #  2) if CWD is the refds
-        refds = res.get('refds', None)
-        refds = refds if kwargs.get('dataset', None) is not None \
-            or refds == os.getcwd() else None
-        path = res['path'] if refds is None \
-            else str(ut.Path(res['path']).relative_to(refds))
-        type_ = res.get('type', res.get('type_src', ''))
-        max_len = len('modified (staged)')
-        state = res['state']
-        if state == 'modified' and 'gitshasum' in res \
-                and 'prev_gitshasum' in res \
-                and res['gitshasum'] != res['prev_gitshasum']:
-            state = 'modified (staged)'
-        ui.message('{fill}{state}: {path}{type_}'.format(
-            fill=' ' * max(0, max_len - len(state)),
-            state=ut.ac.color_word(
-                state,
-                ut.state_color_map.get(res['state'], ut.ac.WHITE)),
-            path=path,
-            type_=' ({})'.format(
-                ut.ac.color_word(type_, ut.ac.MAGENTA) if type_ else '')))
+        RevDiff.custom_result_renderer(res, **kwargs)
 
     @staticmethod
     def custom_result_summary_renderer(results):  # pragma: no cover

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -177,6 +177,18 @@ class RevStatus(Interface):
             untracked='normal',
             recursive=False,
             recursion_limit=None):
+        # To the next white knight that comes in to re-implement `status` as a
+        # special case of `diff`. There is one fundamental difference between
+        # the two commands: `status` can always use the worktree as evident on
+        # disk as a contraint (e.g. to figure out which subdataset a path is in)
+        # `diff` cannot do that (everything need to be handled based on a
+        # "virtual" representation of a dataset hierarchy).
+        # MIH concludes that while `status` can be implemented as a special case
+        # of `diff` doing so would complicate and slow down both `diff` and
+        # `status`. So while the apparent almost code-duplication between the
+        # two commands feels wrong, the benefit is speed. Any future RF should
+        # come with evidence that speed does not suffer, and complexity stays
+        # on a manageable level
         ds = require_dataset(
             dataset, check_installed=True, purpose='status reporting')
 

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -301,6 +301,7 @@ class RevStatus(Interface):
                         "dataset containing given paths is not underneath "
                         "the reference dataset %s: %s",
                         ds, qpaths),
+                    logger=lgr,
                 )
                 continue
             elif qds_inrefds != qdspath:

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -332,11 +332,15 @@ class RevStatus(Interface):
         #path = res['path'].relative_to(res['refds']) \
         #    if res.get('refds', None) else res['path']
         type_ = res.get('type', res.get('type_src', ''))
-        max_len = len('untracked(directory)')
+        max_len = len('modified (staged)')
+        state = res['state']
+        if state == 'modified' and 'gitshasum' in res and 'prev_gitshasum' in res \
+                and res['gitshasum'] != res['prev_gitshasum']:
+            state = 'modified (staged)'
         ui.message('{fill}{state}: {path}{type_}'.format(
-            fill=' ' * max(0, max_len - len(res['state'])),
+            fill=' ' * max(0, max_len - len(state)),
             state=ut.ac.color_word(
-                res['state'],
+                state,
                 ut.state_color_map.get(res['state'], ut.ac.WHITE)),
             path=path,
             type_=' ({})'.format(

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -333,7 +333,7 @@ class RevStatus(Interface):
         #  1) if a dataset arg was given
         #  2) if CWD is the refds
         refds = res.get('refds', None)
-        refds = refds if kwargs['dataset'] is not None \
+        refds = refds if kwargs.get('dataset', None) is not None \
             or refds == os.getcwd() else None
         path = res['path'] if refds is None \
             else str(ut.Path(res['path']).relative_to(refds))

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -27,7 +27,11 @@ from datalad.interface.base import (
     build_doc,
 )
 from datalad.interface.utils import eval_results
-
+from datalad.support.param import Parameter
+from datalad.support.constraints import (
+    EnsureNone,
+    EnsureStr,
+)
 from .dataset import (
     RevolutionDataset as Dataset,
     datasetmethod,
@@ -165,7 +169,16 @@ class RevStatus(Interface):
     # does not yield meaningful output for this command
     result_renderer = 'tailored'
 
-    _params_ = _common_diffstatus_params
+    _params_ = dict(
+        _common_diffstatus_params,
+        path=Parameter(
+            args=("path",),
+            metavar="PATH",
+            doc="""path to be evaluated""",
+            nargs="*",
+            constraints=EnsureStr() | EnsureNone()),
+        )
+
 
     @staticmethod
     @datasetmethod(name='rev_status')

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -19,8 +19,6 @@ from six import (
 )
 from collections import OrderedDict
 
-import datalad.support.ansi_colors as ac
-
 from datalad.utils import (
     assure_list,
 )
@@ -51,13 +49,6 @@ from datalad.support.constraints import EnsureChoice
 from datalad.support.param import Parameter
 
 lgr = logging.getLogger('datalad.revolution.status')
-
-
-state_color_map = {
-    'untracked': ac.RED,
-    'modified': ac.RED,
-    'added': ac.GREEN,
-}
 
 
 def _yield_status(ds, paths, annexinfo, untracked, recursion_limit, queried, cache):
@@ -337,19 +328,19 @@ class RevStatus(Interface):
             # logging reported already
             return
         from datalad.ui import ui
-        path=res['path']
+        path = res['path']
         #path = res['path'].relative_to(res['refds']) \
         #    if res.get('refds', None) else res['path']
         type_ = res.get('type', res.get('type_src', ''))
         max_len = len('untracked(directory)')
         ui.message('{fill}{state}: {path}{type_}'.format(
             fill=' ' * max(0, max_len - len(res['state'])),
-            state=ac.color_word(
+            state=ut.ac.color_word(
                 res['state'],
-                state_color_map.get(res['state'], ac.WHITE)),
+                ut.state_color_map.get(res['state'], ut.ac.WHITE)),
             path=path,
             type_=' ({})'.format(
-                ac.color_word(type_, ac.MAGENTA) if type_ else '')))
+                ut.ac.color_word(type_, ut.ac.MAGENTA) if type_ else '')))
 
     @staticmethod
     def custom_result_summary_renderer(results):  # pragma: no cover

--- a/datalad_revolution/tests/test_diff.py
+++ b/datalad_revolution/tests/test_diff.py
@@ -357,9 +357,15 @@ def test_path_diff(_path, linkpath):
             # change into the realpath of the dataset and
             # query with an explicit path
             with chpwd(ds.path):
-                res = ds.rev_diff(path=op.join('.', rpath), annex='all')
+                res = ds.rev_diff(
+                    path=op.join('.', rpath),
+                    recursive=True,
+                    annex='all')
         else:
-            res = ds.rev_diff(path=p, annex='all')
+            res = ds.rev_diff(
+                path=p,
+                recursive=True,
+                annex='all')
         assert_result_count(
             res,
             1,

--- a/datalad_revolution/tests/test_diff.py
+++ b/datalad_revolution/tests/test_diff.py
@@ -6,13 +6,15 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""test command datalad save
+"""test dataset diff
 
 """
 
 __docformat__ = 'restructuredtext'
 
 from datalad.support.exceptions import CommandError
+
+from datalad.consts import PRE_INIT_COMMIT_SHA
 
 from datalad.tests.utils import (
     with_tempfile,
@@ -32,9 +34,20 @@ from .utils import (
 )
 
 
+@known_failure_windows
+def test_magic_number():
+    # we hard code the magic SHA1 that represents the state of a Git repo
+    # prior to the first commit -- used to diff from scratch to a specific
+    # commit
+    # given the level of dark magic, we better test whether this stays
+    # constant across Git versions (it should!)
+    out, err = GitRunner().run('git hash-object -t tree /dev/null')
+    eq_(out.strip(), PRE_INIT_COMMIT_SHA)
+
+
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-def test_diff(path, norepo):
+def test_repo_diff(path, norepo):
     ds = Dataset(path).rev_create()
     assert_repo_status(ds.path)
     assert_raises(ValueError, ds.repo.diff, fr='WTF', to='MIKE')

--- a/datalad_revolution/tests/test_diff.py
+++ b/datalad_revolution/tests/test_diff.py
@@ -77,7 +77,10 @@ def test_repo_diff(path, norepo):
     eq_(ds.repo.diff(fr='HEAD', to=None),
         {ut.Path(ds.repo.pathobj / 'new'): {
             'state': 'modified',
-            'type': 'file'}})
+            'type': 'file',
+            # the beast is modified, but no change in shasum -> not staged
+            'gitshasum': '7b4d68d70fcae134d5348f5e118f5e9c9d3f05f6',
+            'prev_gitshasum': '7b4d68d70fcae134d5348f5e118f5e9c9d3f05f6'}})
     # per path query gives the same result
     eq_(ds.repo.diff(fr='HEAD', to=None),
         ds.repo.diff(fr='HEAD', to=None, paths=['new']))

--- a/datalad_revolution/tests/test_diff.py
+++ b/datalad_revolution/tests/test_diff.py
@@ -217,7 +217,7 @@ def test_diff_recursive(path):
     ds = Dataset(path).rev_create()
     sub = ds.rev_create('sub')
     # look at the last change, and confirm a dataset was added
-    res = ds.diff(revision='HEAD~1..HEAD')
+    res = ds.rev_diff(fr='HEAD~1', to='HEAD')
     assert_result_count(
         res, 1, action='diff', state='added', path=sub.path, type='dataset')
     # now recursive

--- a/datalad_revolution/tests/test_diff.py
+++ b/datalad_revolution/tests/test_diff.py
@@ -15,6 +15,7 @@ __docformat__ = 'restructuredtext'
 from datalad.support.exceptions import CommandError
 
 from datalad.consts import PRE_INIT_COMMIT_SHA
+from datalad.cmd import GitRunner
 
 from datalad.tests.utils import (
     with_tempfile,
@@ -34,14 +35,13 @@ from .utils import (
 )
 
 
-@known_failure_windows
 def test_magic_number():
     # we hard code the magic SHA1 that represents the state of a Git repo
     # prior to the first commit -- used to diff from scratch to a specific
     # commit
     # given the level of dark magic, we better test whether this stays
     # constant across Git versions (it should!)
-    out, err = GitRunner().run('git hash-object -t tree /dev/null')
+    out, err = GitRunner().run('cd ./ | git hash-object --stdin -t tree')
     eq_(out.strip(), PRE_INIT_COMMIT_SHA)
 
 

--- a/datalad_revolution/tests/test_diff.py
+++ b/datalad_revolution/tests/test_diff.py
@@ -112,3 +112,104 @@ def test_repo_diff(path, norepo):
             ut.Path(ds.repo.pathobj / 'deep' / 'down2'): {
                 'state': 'untracked',
                 'type': 'file'}})
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_diff(path, norepo):
+    with chpwd(norepo):
+        assert_status('impossible', diff(on_failure='ignore'))
+    ds = Dataset(path).create()
+    ok_clean_git(ds.path)
+    # reports stupid revision input
+    assert_result_count(
+        ds.diff(revision='WTF', on_failure='ignore'),
+        1,
+        status='impossible',
+        message="fatal: bad revision 'WTF'")
+    assert_result_count(ds.diff(), 0)
+    # no diff
+    assert_result_count(ds.diff(), 0)
+    assert_result_count(ds.diff(revision='HEAD'), 0)
+    # bogus path makes no difference
+    assert_result_count(ds.diff(path='THIS', revision='HEAD'), 0)
+    # comparing to a previous state we should get a diff in most cases
+    # for this test, let's not care what exactly it is -- will do later
+    assert len(ds.diff(revision='HEAD~1')) > 0
+    # let's introduce a known change
+    create_tree(ds.path, {'new': 'empty'})
+    ds.add('.', to_git=True)
+    ok_clean_git(ds.path)
+    res = ds.diff(revision='HEAD~1')
+    assert_result_count(res, 1)
+    assert_result_count(
+        res, 1, action='diff', path=opj(ds.path, 'new'), state='added')
+    # we can also find the diff without going through the dataset explicitly
+    with chpwd(ds.path):
+        assert_result_count(
+            diff(revision='HEAD~1'), 1,
+            action='diff', path=opj(ds.path, 'new'), state='added')
+    # no diff against HEAD
+    assert_result_count(ds.diff(), 0)
+    # modify known file
+    create_tree(ds.path, {'new': 'notempty'})
+    for diffy in (None, 'HEAD'):
+        res = ds.diff(revision=diffy)
+        assert_result_count(res, 1)
+        assert_result_count(
+            res, 1, action='diff', path=opj(ds.path, 'new'), state='modified')
+    # but if we give another path, it doesn't show up
+    assert_result_count(ds.diff('otherpath'), 0)
+    # giving the right path must work though
+    assert_result_count(
+        ds.diff('new'), 1,
+        action='diff', path=opj(ds.path, 'new'), state='modified')
+    # stage changes
+    ds.add('.', to_git=True, save=False)
+    # no diff, because we staged the modification
+    assert_result_count(ds.diff(), 0)
+    # but we can get at it
+    assert_result_count(
+        ds.diff(staged=True), 1,
+        action='diff', path=opj(ds.path, 'new'), state='modified')
+    # OR
+    assert_result_count(
+        ds.diff(revision='HEAD'), 1,
+        action='diff', path=opj(ds.path, 'new'), state='modified')
+    ds.save()
+    ok_clean_git(ds.path)
+
+    # untracked stuff
+    create_tree(ds.path, {'deep': {'down': 'untracked', 'down2': 'tobeadded'}})
+    # a plain diff should report the untracked file
+    # but not directly, because the parent dir is already unknown
+    res = ds.diff()
+    assert_result_count(res, 1)
+    assert_result_count(
+        res, 1, state='untracked', type='directory', path=opj(ds.path, 'deep'))
+    # report of individual files is also possible
+    assert_result_count(
+        ds.diff(report_untracked='all'), 2, state='untracked', type='file')
+    # an unmatching path will hide this result
+    assert_result_count(ds.diff(path='somewhere'), 0)
+    # perfect match and anything underneath will do
+    assert_result_count(
+        ds.diff(path='deep'), 1, state='untracked', path=opj(ds.path, 'deep'),
+        type='directory')
+    assert_result_count(
+        ds.diff(path='deep'), 1,
+        state='untracked', path=opj(ds.path, 'deep'))
+    # now we stage on of the two files in deep
+    ds.add(opj('deep', 'down2'), to_git=True, save=False)
+    # without any reference it will ignore the staged stuff and report the remaining
+    # untracked file
+    assert_result_count(
+        ds.diff(), 1, state='untracked', path=opj(ds.path, 'deep', 'down'),
+        type='file')
+    res = ds.diff(staged=True)
+    assert_result_count(
+        res, 1, state='untracked', path=opj(ds.path, 'deep', 'down'), type='file')
+    assert_result_count(
+        res, 1, state='added', path=opj(ds.path, 'deep', 'down2'), type='file')
+
+

--- a/datalad_revolution/tests/test_diff.py
+++ b/datalad_revolution/tests/test_diff.py
@@ -221,7 +221,7 @@ def test_diff_recursive(path):
     assert_result_count(
         res, 1, action='diff', state='added', path=sub.path, type='dataset')
     # now recursive
-    res = ds.diff(recursive=True, revision='HEAD~1..HEAD')
+    res = ds.rev_diff(recursive=True, fr='HEAD~1', to='HEAD')
     # we also get the entire diff of the subdataset from scratch
     assert_status('ok', res)
     ok_(len(res) > 3)
@@ -234,8 +234,8 @@ def test_diff_recursive(path):
     create_tree(
         ds.path,
         {'onefile': 'tobeadded', 'sub': {'twofile': 'tobeadded'}})
-    res = ds.diff(recursive=True, report_untracked='all')
-    assert_result_count(res, 3)
+    res = ds.rev_diff(recursive=True, untracked='all')
+    assert_result_count(_dirty_results(res), 3)
     assert_result_count(
         res, 1,
         action='diff', state='untracked', path=op.join(ds.path, 'onefile'),
@@ -252,8 +252,8 @@ def test_diff_recursive(path):
     ds.rev_save()
     assert_repo_status(ds.path)
     # look at the last change, only one file was added
-    res = ds.diff(revision='HEAD~1..HEAD')
-    assert_result_count(res, 1)
+    res = ds.rev_diff(fr='HEAD~1', to='HEAD')
+    assert_result_count(_dirty_results(res), 1)
     assert_result_count(
         res, 1,
         action='diff', state='added', path=op.join(ds.path, 'onefile'),
@@ -261,8 +261,8 @@ def test_diff_recursive(path):
 
     # now the exact same thing with recursion, must not be different from the
     # call above
-    res = ds.diff(recursive=True, revision='HEAD~1..HEAD')
-    assert_result_count(res, 1)
+    res = ds.rev_diff(recursive=True, fr='HEAD~1', to='HEAD')
+    assert_result_count(_dirty_results(res), 1)
     # last change in parent
     assert_result_count(
         res, 1, action='diff', state='added', path=op.join(ds.path, 'onefile'),
@@ -270,8 +270,8 @@ def test_diff_recursive(path):
 
     # one further back brings in the modified subdataset, and the added file
     # within it
-    res = ds.diff(recursive=True, revision='HEAD~2..HEAD')
-    assert_result_count(res, 3)
+    res = ds.rev_diff(recursive=True, fr='HEAD~2', to='HEAD')
+    assert_result_count(_dirty_results(res), 3)
     assert_result_count(
         res, 1,
         action='diff', state='added', path=op.join(ds.path, 'onefile'),

--- a/datalad_revolution/tests/test_diff.py
+++ b/datalad_revolution/tests/test_diff.py
@@ -387,3 +387,24 @@ def test_path_diff(_path, linkpath):
         ds.rev_diff(recursive=True, recursion_limit=-1),
         ds.rev_diff(recursive=True)
     )
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_diff_nods(path, otherpath):
+    ds = Dataset(path).rev_create()
+    assert_result_count(
+        ds.rev_diff(path=otherpath, on_failure='ignore'),
+        1,
+        status='error',
+        message='path not underneath this dataset')
+    otherds = Dataset(otherpath).rev_create()
+    assert_result_count(
+        ds.rev_diff(path=otherpath, on_failure='ignore'),
+        1,
+        path=otherds.path,
+        status='error',
+        message=(
+            'dataset containing given paths is not underneath the '
+            'reference dataset %s: %s', ds, otherds.path)
+    )

--- a/datalad_revolution/tests/test_diff.py
+++ b/datalad_revolution/tests/test_diff.py
@@ -314,7 +314,7 @@ def test_path_diff(_path, linkpath):
         # check the premise of this test
         assert ds.pathobj != ds.repo.pathobj
 
-    plain_recursive = ds.rev_diff(recursive=True)
+    plain_recursive = ds.rev_diff(recursive=True, annex='all')
     # check integrity of individual reports with a focus on how symlinks
     # are reported
     for res in plain_recursive:
@@ -332,19 +332,19 @@ def test_path_diff(_path, linkpath):
 
     # bunch of smoke tests
     # query of '.' is same as no path
-    eq_(plain_recursive, ds.rev_diff(path='.', recursive=True))
+    eq_(plain_recursive, ds.rev_diff(path='.', recursive=True, annex='all'))
     # duplicate paths do not change things
-    eq_(plain_recursive, ds.rev_diff(path=['.', '.'], recursive=True))
+    eq_(plain_recursive, ds.rev_diff(path=['.', '.'], recursive=True, annex='all'))
     # neither do nested paths
     eq_(plain_recursive,
-        ds.rev_diff(path=['.', 'subds_modified'], recursive=True))
+        ds.rev_diff(path=['.', 'subds_modified'], recursive=True, annex='all'))
     # when invoked in a subdir of a dataset it still reports on the full thing
     # just like `git status`, as long as there are no paths specified
     with chpwd(op.join(path, 'directory_untracked')):
-        plain_recursive = diff(recursive=True)
+        plain_recursive = diff(recursive=True, annex='all')
     # should be able to take absolute paths and yield the same
     # output
-    eq_(plain_recursive, ds.rev_diff(path=ds.path, recursive=True))
+    eq_(plain_recursive, ds.rev_diff(path=ds.path, recursive=True, annex='all'))
 
     # query for a deeply nested path from the top, should just work with a
     # variety of approaches
@@ -357,9 +357,9 @@ def test_path_diff(_path, linkpath):
             # change into the realpath of the dataset and
             # query with an explicit path
             with chpwd(ds.path):
-                res = ds.rev_diff(path=op.join('.', rpath))
+                res = ds.rev_diff(path=op.join('.', rpath), annex='all')
         else:
-            res = ds.rev_diff(path=p)
+            res = ds.rev_diff(path=p, annex='all')
         assert_result_count(
             res,
             1,

--- a/datalad_revolution/tests/test_diff.py
+++ b/datalad_revolution/tests/test_diff.py
@@ -12,7 +12,12 @@
 
 __docformat__ = 'restructuredtext'
 
-from datalad.support.exceptions import CommandError
+import os.path as op
+from datalad.support.exceptions import (
+    NoDatasetArgumentFound,
+    CommandError,
+    IncompleteResultsError,
+)
 
 from datalad.consts import PRE_INIT_COMMIT_SHA
 from datalad.cmd import GitRunner
@@ -22,6 +27,9 @@ from datalad.tests.utils import (
     create_tree,
     eq_,
     assert_raises,
+    chpwd,
+    assert_status,
+    assert_result_count,
 )
 
 from .. import utils as ut
@@ -29,6 +37,7 @@ from ..dataset import RevolutionDataset as Dataset
 from datalad.api import (
     rev_save as save,
     rev_create as create,
+    rev_diff as diff,
 )
 from .utils import (
     assert_repo_status,
@@ -114,102 +123,88 @@ def test_repo_diff(path, norepo):
                 'type': 'file'}})
 
 
+def _dirty_results(res):
+    return [r for r in res if r.get('state', None) != 'clean']
+
+
+# this is an extended variant of `test_repo_diff()` above
+# that focuses on the high-level command API
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_diff(path, norepo):
     with chpwd(norepo):
-        assert_status('impossible', diff(on_failure='ignore'))
-    ds = Dataset(path).create()
-    ok_clean_git(ds.path)
+        assert_raises(NoDatasetArgumentFound, diff)
+    ds = Dataset(path).rev_create()
+    assert_repo_status(ds.path)
     # reports stupid revision input
     assert_result_count(
-        ds.diff(revision='WTF', on_failure='ignore'),
+        ds.rev_diff(fr='WTF', on_failure='ignore'),
         1,
         status='impossible',
-        message="fatal: bad revision 'WTF'")
-    assert_result_count(ds.diff(), 0)
+        message="Git reference 'WTF' invalid")
     # no diff
-    assert_result_count(ds.diff(), 0)
-    assert_result_count(ds.diff(revision='HEAD'), 0)
+    assert_result_count(_dirty_results(ds.rev_diff()), 0)
+    assert_result_count(_dirty_results(ds.rev_diff(fr='HEAD')), 0)
     # bogus path makes no difference
-    assert_result_count(ds.diff(path='THIS', revision='HEAD'), 0)
-    # comparing to a previous state we should get a diff in most cases
-    # for this test, let's not care what exactly it is -- will do later
-    assert len(ds.diff(revision='HEAD~1')) > 0
+    assert_result_count(_dirty_results(ds.rev_diff(path='THIS', fr='HEAD')), 0)
     # let's introduce a known change
     create_tree(ds.path, {'new': 'empty'})
-    ds.add('.', to_git=True)
-    ok_clean_git(ds.path)
-    res = ds.diff(revision='HEAD~1')
+    ds.rev_save(to_git=True)
+    assert_repo_status(ds.path)
+    res = _dirty_results(ds.rev_diff(fr='HEAD~1'))
     assert_result_count(res, 1)
     assert_result_count(
-        res, 1, action='diff', path=opj(ds.path, 'new'), state='added')
+        res, 1, action='diff', path=op.join(ds.path, 'new'), state='added')
     # we can also find the diff without going through the dataset explicitly
     with chpwd(ds.path):
         assert_result_count(
-            diff(revision='HEAD~1'), 1,
-            action='diff', path=opj(ds.path, 'new'), state='added')
+            _dirty_results(diff(fr='HEAD~1')), 1,
+            action='diff', path=op.join(ds.path, 'new'), state='added')
     # no diff against HEAD
-    assert_result_count(ds.diff(), 0)
+    assert_result_count(_dirty_results(ds.rev_diff()), 0)
     # modify known file
     create_tree(ds.path, {'new': 'notempty'})
-    for diffy in (None, 'HEAD'):
-        res = ds.diff(revision=diffy)
-        assert_result_count(res, 1)
-        assert_result_count(
-            res, 1, action='diff', path=opj(ds.path, 'new'), state='modified')
+    res = _dirty_results(ds.rev_diff())
+    assert_result_count(res, 1)
+    assert_result_count(
+        res, 1, action='diff', path=op.join(ds.path, 'new'),
+        state='modified')
     # but if we give another path, it doesn't show up
-    assert_result_count(ds.diff('otherpath'), 0)
+    assert_result_count(ds.rev_diff(path='otherpath'), 0)
     # giving the right path must work though
     assert_result_count(
-        ds.diff('new'), 1,
-        action='diff', path=opj(ds.path, 'new'), state='modified')
+        ds.rev_diff(path='new'), 1,
+        action='diff', path=op.join(ds.path, 'new'), state='modified')
     # stage changes
-    ds.add('.', to_git=True, save=False)
-    # no diff, because we staged the modification
-    assert_result_count(ds.diff(), 0)
-    # but we can get at it
-    assert_result_count(
-        ds.diff(staged=True), 1,
-        action='diff', path=opj(ds.path, 'new'), state='modified')
-    # OR
-    assert_result_count(
-        ds.diff(revision='HEAD'), 1,
-        action='diff', path=opj(ds.path, 'new'), state='modified')
-    ds.save()
-    ok_clean_git(ds.path)
+    ds.repo.add('.', git=True)
+    # no change in diff, staged is not commited
+    assert_result_count(_dirty_results(ds.rev_diff()), 1)
+    ds.rev_save()
+    assert_repo_status(ds.path)
+    assert_result_count(_dirty_results(ds.rev_diff()), 0)
 
     # untracked stuff
     create_tree(ds.path, {'deep': {'down': 'untracked', 'down2': 'tobeadded'}})
     # a plain diff should report the untracked file
     # but not directly, because the parent dir is already unknown
-    res = ds.diff()
+    res = _dirty_results(ds.rev_diff())
     assert_result_count(res, 1)
     assert_result_count(
-        res, 1, state='untracked', type='directory', path=opj(ds.path, 'deep'))
+        res, 1, state='untracked', type='directory', path=op.join(ds.path, 'deep'))
     # report of individual files is also possible
     assert_result_count(
-        ds.diff(report_untracked='all'), 2, state='untracked', type='file')
+        ds.rev_diff(untracked='all'), 2, state='untracked', type='file')
     # an unmatching path will hide this result
-    assert_result_count(ds.diff(path='somewhere'), 0)
+    assert_result_count(ds.rev_diff(path='somewhere'), 0)
     # perfect match and anything underneath will do
     assert_result_count(
-        ds.diff(path='deep'), 1, state='untracked', path=opj(ds.path, 'deep'),
+        ds.rev_diff(path='deep'), 1, state='untracked', path=op.join(ds.path, 'deep'),
         type='directory')
     assert_result_count(
-        ds.diff(path='deep'), 1,
-        state='untracked', path=opj(ds.path, 'deep'))
-    # now we stage on of the two files in deep
-    ds.add(opj('deep', 'down2'), to_git=True, save=False)
-    # without any reference it will ignore the staged stuff and report the remaining
-    # untracked file
+        ds.rev_diff(path='deep'), 1,
+        state='untracked', path=op.join(ds.path, 'deep'))
+    ds.repo.add(op.join('deep', 'down2'), git=True)
+    # now the remaining file is the only untracked one
     assert_result_count(
-        ds.diff(), 1, state='untracked', path=opj(ds.path, 'deep', 'down'),
+        ds.rev_diff(), 1, state='untracked', path=op.join(ds.path, 'deep', 'down'),
         type='file')
-    res = ds.diff(staged=True)
-    assert_result_count(
-        res, 1, state='untracked', path=opj(ds.path, 'deep', 'down'), type='file')
-    assert_result_count(
-        res, 1, state='added', path=opj(ds.path, 'deep', 'down2'), type='file')
-
-

--- a/datalad_revolution/tests/test_diff.py
+++ b/datalad_revolution/tests/test_diff.py
@@ -15,8 +15,6 @@ __docformat__ = 'restructuredtext'
 import os.path as op
 from datalad.support.exceptions import (
     NoDatasetArgumentFound,
-    CommandError,
-    IncompleteResultsError,
 )
 
 from datalad.consts import PRE_INIT_COMMIT_SHA
@@ -28,7 +26,6 @@ from datalad.tests.utils import (
     eq_,
     assert_raises,
     chpwd,
-    assert_status,
     assert_result_count,
 )
 
@@ -190,7 +187,8 @@ def test_diff(path, norepo):
     res = _dirty_results(ds.rev_diff())
     assert_result_count(res, 1)
     assert_result_count(
-        res, 1, state='untracked', type='directory', path=op.join(ds.path, 'deep'))
+        res, 1, state='untracked', type='directory',
+        path=op.join(ds.path, 'deep'))
     # report of individual files is also possible
     assert_result_count(
         ds.rev_diff(untracked='all'), 2, state='untracked', type='file')
@@ -198,7 +196,8 @@ def test_diff(path, norepo):
     assert_result_count(ds.rev_diff(path='somewhere'), 0)
     # perfect match and anything underneath will do
     assert_result_count(
-        ds.rev_diff(path='deep'), 1, state='untracked', path=op.join(ds.path, 'deep'),
+        ds.rev_diff(path='deep'), 1, state='untracked',
+        path=op.join(ds.path, 'deep'),
         type='directory')
     assert_result_count(
         ds.rev_diff(path='deep'), 1,
@@ -206,5 +205,6 @@ def test_diff(path, norepo):
     ds.repo.add(op.join('deep', 'down2'), git=True)
     # now the remaining file is the only untracked one
     assert_result_count(
-        ds.rev_diff(), 1, state='untracked', path=op.join(ds.path, 'deep', 'down'),
+        ds.rev_diff(), 1, state='untracked',
+        path=op.join(ds.path, 'deep', 'down'),
         type='file')

--- a/datalad_revolution/tests/test_save.py
+++ b/datalad_revolution/tests/test_save.py
@@ -35,6 +35,7 @@ from datalad.tests.utils import (
 )
 from datalad.distribution.tests.test_add import tree_arg
 
+from .. import utils as ut
 from ..dataset import RevolutionDataset as Dataset
 from ..annexrepo import RevolutionAnnexRepo as AnnexRepo
 from datalad.api import (
@@ -336,7 +337,8 @@ def test_add_files(path):
             result = ds.rev_save(arg[0], to_git=arg[1])
             for a in assure_list(arg[0]):
                 assert_result_count(result, 1, path=str(ds.pathobj / a))
-            status = ds.repo.get_content_annexinfo(assure_list(arg[0]))
+            status = ds.repo.get_content_annexinfo(
+                ut.Path(p) for p in assure_list(arg[0]))
         for f, p in iteritems(status):
             if arg[1]:
                 assert p.get('key', None) is None, f
@@ -456,7 +458,7 @@ def test_gh1597_simpler(path):
     # no annex key, not in annex
     assert_not_in(
         'key',
-        ds.repo.get_content_annexinfo([attrfile]).popitem()[1])
+        ds.repo.get_content_annexinfo([ut.Path(attrfile)]).popitem()[1])
 
 
 @with_tempfile(mkdir=True)

--- a/datalad_revolution/utils.py
+++ b/datalad_revolution/utils.py
@@ -1,4 +1,5 @@
 from six import PY2
+import datalad.support.ansi_colors as ac
 
 # handle this dance once, and import pathlib from here
 # in all other places
@@ -12,6 +13,13 @@ else:
         Path,
         PurePosixPath,
     )
+
+
+state_color_map = {
+    'untracked': ac.RED,
+    'modified': ac.RED,
+    'added': ac.GREEN,
+}
 
 
 def nothere(*args, **kwargs):


### PR DESCRIPTION
State: Ready for testing.

- [x] enhance Repo.diffstatus() output with state **change** info. ATM only the final state (but not the original is known)
- [x] be able to actually switch off recursion
- [x] test proper path handling/reporting for constrained diffs (not tested in -core `diff` at all)
- [x] make annex-aware (maybe report key or size differences)
- [x] document
- [x] implement dedicated renderer (should compare reported shasums to indicate whether a change was saved or not)
- [x] correctly handle constraining paths that are located in subdatasets (ATM the lead to NULL reports, even if the parent dataset is reported as modified in the base dataset)
- implement dedicated diff summary renderer (#files changed, added, deleted) -- not sure if that useful, or if (and then how) it should be conditional on some switch