### PR TITLE
RF: relative imports

### DIFF
--- a/datalad_revolution/annexrepo.py
+++ b/datalad_revolution/annexrepo.py
@@ -16,7 +16,7 @@ from . import utils as ut
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import CommandError
 
-from datalad_revolution.gitrepo import (
+from .gitrepo import (
     RevolutionGitRepo,
     obsolete_methods as gitrepo_obsolete_methods,
 )

--- a/datalad_revolution/annexrepo.py
+++ b/datalad_revolution/annexrepo.py
@@ -11,7 +11,7 @@ from weakref import WeakValueDictionary
 from datalad.utils import on_windows
 from datalad.ui import ui
 
-import datalad_revolution.utils as ut
+from . import utils as ut
 
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import CommandError

--- a/datalad_revolution/dataset.py
+++ b/datalad_revolution/dataset.py
@@ -28,8 +28,8 @@ from datalad.utils import (
     getpwd,
 )
 
-from datalad_revolution.gitrepo import RevolutionGitRepo
-from datalad_revolution.annexrepo import RevolutionAnnexRepo
+from .gitrepo import RevolutionGitRepo
+from .annexrepo import RevolutionAnnexRepo
 
 lgr = logging.getLogger('datalad.revolution.dataset')
 

--- a/datalad_revolution/dataset.py
+++ b/datalad_revolution/dataset.py
@@ -10,7 +10,7 @@ from six import (
 import wrapt
 from weakref import WeakValueDictionary
 import logging
-import datalad_revolution.utils as ut
+from . import utils as ut
 
 from datalad.distribution.dataset import (
     Dataset as _Dataset,

--- a/datalad_revolution/gitrepo.py
+++ b/datalad_revolution/gitrepo.py
@@ -16,7 +16,7 @@ from weakref import WeakValueDictionary
 from datalad.utils import assure_list
 
 from datalad.dochelpers import exc_str
-import datalad_revolution.utils as ut
+from . import utils as ut
 from datalad.support.gitrepo import (
     GitRepo,
     InvalidGitRepositoryError,

--- a/datalad_revolution/revcreate.py
+++ b/datalad_revolution/revcreate.py
@@ -51,7 +51,7 @@ from datalad_revolution.revsave import RevSave
 
 from datalad_revolution.gitrepo import RevolutionGitRepo as GitRepo
 from datalad_revolution.annexrepo import RevolutionAnnexRepo as AnnexRepo
-import datalad_revolution.utils as ut
+from . import utils as ut
 
 
 __docformat__ = 'restructuredtext'

--- a/datalad_revolution/revcreate.py
+++ b/datalad_revolution/revcreate.py
@@ -37,7 +37,7 @@ from datalad.support.constraints import (
 from datalad.support.param import Parameter
 from datalad.utils import getpwd
 
-from datalad_revolution.dataset import (
+from .dataset import (
     RevolutionDataset as Dataset,
     datasetmethod,
     EnsureDataset,
@@ -47,10 +47,10 @@ from datalad_revolution.dataset import (
     require_dataset,
 )
 # for bound dataset method
-from datalad_revolution.revsave import RevSave
+from .revsave import RevSave
 
-from datalad_revolution.gitrepo import RevolutionGitRepo as GitRepo
-from datalad_revolution.annexrepo import RevolutionAnnexRepo as AnnexRepo
+from .gitrepo import RevolutionGitRepo as GitRepo
+from .annexrepo import RevolutionAnnexRepo as AnnexRepo
 from . import utils as ut
 
 

--- a/datalad_revolution/revrun.py
+++ b/datalad_revolution/revrun.py
@@ -19,11 +19,11 @@ from datalad.interface.run import (
     build_doc,
     eval_results,
 )
-from datalad_revolution.dataset import (
+from .dataset import (
     RevolutionDataset as Dataset,
     datasetmethod,
 )
-from datalad_revolution.revsave import RevSave
+from .revsave import RevSave
 
 lgr = logging.getLogger('datalad.revolution.run')
 

--- a/datalad_revolution/revsave.py
+++ b/datalad_revolution/revsave.py
@@ -40,13 +40,13 @@ from datalad.utils import (
 )
 from . import utils as ut
 
-from datalad_revolution.dataset import (
+from .dataset import (
     RevolutionDataset as Dataset,
     EnsureDataset,
     datasetmethod,
     require_dataset,
 )
-from datalad_revolution.revstatus import (
+from .revstatus import (
     RevStatus as Status,
 )
 

--- a/datalad_revolution/revsave.py
+++ b/datalad_revolution/revsave.py
@@ -38,7 +38,7 @@ from datalad.support.exceptions import CommandError
 from datalad.utils import (
     assure_list,
 )
-import datalad_revolution.utils as ut
+from . import utils as ut
 
 from datalad_revolution.dataset import (
     RevolutionDataset as Dataset,

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -43,7 +43,7 @@ from datalad_revolution.dataset import (
     path_under_dataset,
     get_dataset_root,
 )
-import datalad_revolution.utils as ut
+from . import utils as ut
 
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureStr

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -34,7 +34,7 @@ from datalad.interface.common_opts import (
     recursion_flag,
 )
 
-from datalad_revolution.dataset import (
+from .dataset import (
     RevolutionDataset as Dataset,
     EnsureDataset,
     datasetmethod,

--- a/datalad_revolution/tests/test_create.py
+++ b/datalad_revolution/tests/test_create.py
@@ -37,7 +37,7 @@ from datalad.tests.utils import (
     with_tree,
 )
 
-from datalad_revolution.tests.utils import assert_repo_status
+from .utils import assert_repo_status
 
 
 _dataset_hierarchy_template = {

--- a/datalad_revolution/tests/test_create.py
+++ b/datalad_revolution/tests/test_create.py
@@ -15,7 +15,7 @@ from datalad.tests.utils import known_failure_windows
 import os
 import os.path as op
 
-from datalad_revolution.dataset import (
+from ..dataset import (
     RevolutionDataset as Dataset
 )
 from datalad.api import rev_create as create

--- a/datalad_revolution/tests/test_diff.py
+++ b/datalad_revolution/tests/test_diff.py
@@ -27,7 +27,7 @@ from datalad.api import (
     rev_save as save,
     rev_create as create,
 )
-from datalad_revolution.tests.utils import (
+from .utils import (
     assert_repo_status,
 )
 

--- a/datalad_revolution/tests/test_diff.py
+++ b/datalad_revolution/tests/test_diff.py
@@ -22,7 +22,7 @@ from datalad.tests.utils import (
 )
 
 import datalad_revolution.utils as ut
-from datalad_revolution.dataset import RevolutionDataset as Dataset
+from ..dataset import RevolutionDataset as Dataset
 from datalad.api import (
     rev_save as save,
     rev_create as create,

--- a/datalad_revolution/tests/test_diff.py
+++ b/datalad_revolution/tests/test_diff.py
@@ -21,7 +21,7 @@ from datalad.tests.utils import (
     assert_raises,
 )
 
-import datalad_revolution.utils as ut
+from .. import utils as ut
 from ..dataset import RevolutionDataset as Dataset
 from datalad.api import (
     rev_save as save,

--- a/datalad_revolution/tests/test_fileinfo.py
+++ b/datalad_revolution/tests/test_fileinfo.py
@@ -19,8 +19,8 @@ from datalad.tests.utils import (
     assert_raises,
 )
 
-from datalad_revolution.dataset import RevolutionDataset as Dataset
-from datalad_revolution.gitrepo import RevolutionGitRepo as GitRepo
+from ..dataset import RevolutionDataset as Dataset
+from ..gitrepo import RevolutionGitRepo as GitRepo
 from .utils import (
     assert_repo_status,
     get_convoluted_situation,

--- a/datalad_revolution/tests/test_fileinfo.py
+++ b/datalad_revolution/tests/test_fileinfo.py
@@ -21,7 +21,7 @@ from datalad.tests.utils import (
 
 from datalad_revolution.dataset import RevolutionDataset as Dataset
 from datalad_revolution.gitrepo import RevolutionGitRepo as GitRepo
-from datalad_revolution.tests.utils import (
+from .utils import (
     assert_repo_status,
     get_convoluted_situation,
 )

--- a/datalad_revolution/tests/test_fileinfo.py
+++ b/datalad_revolution/tests/test_fileinfo.py
@@ -8,7 +8,7 @@
 """Test file info getters"""
 
 import os.path as op
-import datalad_revolution.utils as ut
+from .. import utils as ut
 
 from datalad.tests.utils import (
     with_tempfile,

--- a/datalad_revolution/tests/test_repo_save.py
+++ b/datalad_revolution/tests/test_repo_save.py
@@ -17,9 +17,9 @@ from datalad.tests.utils import (
     eq_,
 )
 
-from datalad_revolution.dataset import RevolutionDataset as Dataset
-from datalad_revolution.gitrepo import RevolutionGitRepo as GitRepo
-from datalad_revolution.annexrepo import RevolutionAnnexRepo as AnnexRepo
+from ..dataset import RevolutionDataset as Dataset
+from ..gitrepo import RevolutionGitRepo as GitRepo
+from ..annexrepo import RevolutionAnnexRepo as AnnexRepo
 from .utils import (
     assert_repo_status,
     get_convoluted_situation,

--- a/datalad_revolution/tests/test_repo_save.py
+++ b/datalad_revolution/tests/test_repo_save.py
@@ -20,7 +20,7 @@ from datalad.tests.utils import (
 from datalad_revolution.dataset import RevolutionDataset as Dataset
 from datalad_revolution.gitrepo import RevolutionGitRepo as GitRepo
 from datalad_revolution.annexrepo import RevolutionAnnexRepo as AnnexRepo
-from datalad_revolution.tests.utils import (
+from .utils import (
     assert_repo_status,
     get_convoluted_situation,
 )

--- a/datalad_revolution/tests/test_run.py
+++ b/datalad_revolution/tests/test_run.py
@@ -31,7 +31,7 @@ from datalad.utils import (
     on_windows,
 )
 
-from datalad_revolution.dataset import RevolutionDataset as Dataset
+from ..dataset import RevolutionDataset as Dataset
 from .utils import assert_repo_status
 from datalad.support.exceptions import (
     NoDatasetArgumentFound,
@@ -41,7 +41,7 @@ from datalad.api import (
     install,
     rev_run as run,
 )
-from datalad_revolution.revrun import (
+from ..revrun import (
     GlobbedPaths,
     run_command,
 )

--- a/datalad_revolution/tests/test_run.py
+++ b/datalad_revolution/tests/test_run.py
@@ -32,7 +32,7 @@ from datalad.utils import (
 )
 
 from datalad_revolution.dataset import RevolutionDataset as Dataset
-from datalad_revolution.tests.utils import assert_repo_status
+from .utils import assert_repo_status
 from datalad.support.exceptions import (
     NoDatasetArgumentFound,
     CommandError,

--- a/datalad_revolution/tests/test_save.py
+++ b/datalad_revolution/tests/test_save.py
@@ -35,8 +35,8 @@ from datalad.tests.utils import (
 )
 from datalad.distribution.tests.test_add import tree_arg
 
-from datalad_revolution.dataset import RevolutionDataset as Dataset
-from datalad_revolution.annexrepo import RevolutionAnnexRepo as AnnexRepo
+from ..dataset import RevolutionDataset as Dataset
+from ..annexrepo import RevolutionAnnexRepo as AnnexRepo
 from datalad.api import (
     rev_save as save,
     rev_create as create,

--- a/datalad_revolution/tests/test_save.py
+++ b/datalad_revolution/tests/test_save.py
@@ -43,7 +43,7 @@ from datalad.api import (
     install,
 )
 
-from datalad_revolution.tests.utils import (
+from .utils import (
     assert_repo_status,
     skip_wo_symlink_capability,
 )

--- a/datalad_revolution/tests/test_status.py
+++ b/datalad_revolution/tests/test_status.py
@@ -29,7 +29,7 @@ from datalad.support.exceptions import (
 )
 from datalad_revolution.dataset import RevolutionDataset as Dataset
 from datalad_revolution.annexrepo import RevolutionAnnexRepo as AnnexRepo
-from datalad_revolution.tests.utils import (
+from .utils import (
     get_deeply_nested_structure,
     has_symlink_capability,
 )

--- a/datalad_revolution/tests/test_status.py
+++ b/datalad_revolution/tests/test_status.py
@@ -27,8 +27,8 @@ from datalad.support.exceptions import (
     NoDatasetArgumentFound,
     IncompleteResultsError,
 )
-from datalad_revolution.dataset import RevolutionDataset as Dataset
-from datalad_revolution.annexrepo import RevolutionAnnexRepo as AnnexRepo
+from ..dataset import RevolutionDataset as Dataset
+from ..annexrepo import RevolutionAnnexRepo as AnnexRepo
 from .utils import (
     get_deeply_nested_structure,
     has_symlink_capability,

--- a/datalad_revolution/tests/test_status.py
+++ b/datalad_revolution/tests/test_status.py
@@ -9,7 +9,7 @@
 
 import os.path as op
 from six import text_type
-import datalad_revolution.utils as ut
+from .. import utils as ut
 
 from datalad.utils import (
     chpwd,

--- a/datalad_revolution/tests/test_utils.py
+++ b/datalad_revolution/tests/test_utils.py
@@ -12,7 +12,7 @@ from datalad.tests.utils import (
     on_windows,
 )
 
-from datalad_revolution.dataset import (
+from ..dataset import (
     RevolutionDataset as Dataset,
     resolve_path,
 )

--- a/datalad_revolution/tests/test_utils.py
+++ b/datalad_revolution/tests/test_utils.py
@@ -17,7 +17,7 @@ from ..dataset import (
     resolve_path,
 )
 
-import datalad_revolution.utils as ut
+from .. import utils as ut
 
 
 @with_tempfile(mkdir=True)

--- a/datalad_revolution/tests/utils.py
+++ b/datalad_revolution/tests/utils.py
@@ -23,7 +23,7 @@ from datalad.tests.utils import (
     SkipTest,
 )
 
-import datalad_revolution.utils as ut
+from .. import utils as ut
 
 
 def assert_repo_status(path, annex=None, untracked_mode='normal', **kwargs):

--- a/datalad_revolution/tests/utils.py
+++ b/datalad_revolution/tests/utils.py
@@ -12,9 +12,9 @@ from datalad.api import (
     rev_create as create,
 )
 
-from datalad_revolution.gitrepo import RevolutionGitRepo as GitRepo
-from datalad_revolution.annexrepo import RevolutionAnnexRepo as AnnexRepo
-from datalad_revolution.dataset import RevolutionDataset as Dataset
+from ..gitrepo import RevolutionGitRepo as GitRepo
+from ..annexrepo import RevolutionAnnexRepo as AnnexRepo
+from ..dataset import RevolutionDataset as Dataset
 
 from datalad.tests.utils import (
     assert_is,


### PR DESCRIPTION
all commits are the `datalad run` commits so later could be repeated on the new codebase