### PR TITLE
BF: Symlink issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,12 @@ env:
     - DATALAD_REPO_VERSION=5
     - DATALAD_REPO_VERSION=6
 
+matrix:
+  include:
+  - python: 3.5
+    env:
+    # eventually: - TMPDIR="/var/tmp/sym ссылка"
+    - TMPDIR="/var/tmp/sym link"
 
 before_install:
   # Just in case we need to check if nfs is there etc
@@ -49,6 +55,9 @@ install:
   #- pip install 'sphinx>=1.6.2'
   # So we could test under sudo -E with PATH pointing to installed location
   - sudo sed -i -e 's/^Defaults.*secure_path.*$//' /etc/sudoers
+  # TMPDIRs
+  - if [[ "${TMPDIR:-}" =~ .*/sym\ link ]]; then echo "Symlinking $TMPDIR"; ln -s /tmp "$TMPDIR"; fi
+  - if [[ "${TMPDIR:-}" =~ .*/d\ i\ r ]]; then echo "mkdir $TMPDIR"; mkdir -p "$TMPDIR"; fi
 
 script:
   # Verify that setup.py build doesn't puke

--- a/datalad_revolution/revcreate.py
+++ b/datalad_revolution/revcreate.py
@@ -244,11 +244,14 @@ class RevCreate(Interface):
         parentds_path = get_dataset_root(
             op.normpath(op.join(str(path), os.pardir)))
         if parentds_path:
+            prepo = GitRepo(parentds_path)
+            parentds_path = ut.Path(parentds_path)
             # we cannot get away with a simple
             # GitRepo.get_content_info(), as we need to detect
             # uninstalled/added subdatasets too
-            subds_status = {k for k, v in iteritems(
-                GitRepo(parentds_path).status(untracked='no'))
+            subds_status = {
+                parentds_path / k.relative_to(prepo.path)
+                for k, v in iteritems(prepo.status(untracked='no'))
                 if v.get('type', None) == 'dataset'}
             check_paths = [ut.Path(path)]
             check_paths.extend(ut.Path(path).parents)
@@ -259,7 +262,7 @@ class RevCreate(Interface):
                     'message': (
                         'collision with %s (dataset) in dataset %s',
                         str(conflict[0]),
-                        parentds_path)})
+                        str(parentds_path))})
                 yield res
                 return
 

--- a/datalad_revolution/revcreate.py
+++ b/datalad_revolution/revcreate.py
@@ -288,14 +288,14 @@ class RevCreate(Interface):
         # create and configure desired repository
         if no_annex:
             lgr.info("Creating a new git repo at %s", tbds.path)
-            GitRepo(
+            tbrepo = GitRepo(
                 tbds.path,
                 url=None,
                 create=True,
                 git_opts=initopts,
                 fake_dates=fake_dates)
             # place a .noannex file to indicate annex to leave this repo alone
-            stamp_path = ut.Path(tbds.path) / '.noannex'
+            stamp_path = ut.Path(tbrepo.path) / '.noannex'
             stamp_path.touch()
             add_to_git[stamp_path] = {
                 'type': 'file',

--- a/datalad_revolution/revcreate.py
+++ b/datalad_revolution/revcreate.py
@@ -82,7 +82,6 @@ class YieldDatasets(ResultXFM):
             lgr.debug('rejected by return value configuration: %s', res)
 
 
-
 @build_doc
 class RevCreate(Interface):
     """Create a new dataset from scratch.
@@ -124,8 +123,9 @@ class RevCreate(Interface):
     # result_xfm = 'datasets'
     result_xfm = YieldDatasets()
     # result filter
-    result_filter = EnsureKeyChoice('action', ('create',)) & \
-                    EnsureKeyChoice('status', ('ok', 'notneeded'))
+    result_filter = \
+        EnsureKeyChoice('action', ('create',)) & \
+        EnsureKeyChoice('status', ('ok', 'notneeded'))
 
     _params_ = dict(
         path=Parameter(
@@ -189,7 +189,6 @@ class RevCreate(Interface):
             fake_dates=False
     ):
         refds_path = dataset.path if hasattr(dataset, 'path') else dataset
-        orig_path = path
 
         # two major cases
         # 1. we got a `dataset` -> we either want to create it (path is None),
@@ -419,8 +418,8 @@ class RevCreate(Interface):
     def custom_result_renderer(res, **kwargs):  # pragma: no cover
         from datalad.ui import ui
         if res.get('action', None) == 'create' and \
-               res.get('status', None) == 'ok' and \
-               res.get('type', None) == 'dataset':
+                res.get('status', None) == 'ok' and \
+                res.get('type', None) == 'dataset':
             ui.message("Created dataset at {}.".format(res['path']))
         else:
             ui.message("Nothing was created")

--- a/datalad_revolution/revsave.py
+++ b/datalad_revolution/revsave.py
@@ -260,7 +260,11 @@ class RevSave(Interface):
                     # version
                     for k in ('path', 'refds'):
                         if k in res:
-                            res[k] = str(res[k])
+                            res[k] = str(
+                                # recode path back to dataset path anchor
+                                pds.pathobj / res[k].relative_to(
+                                    pds.repo.pathobj)
+                            )
                     yield res
             # report on the dataset itself
             dsres = dict(

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -67,7 +67,8 @@ def _yield_status(ds, paths, annexinfo, untracked, recursion_limit, queried, cac
     status = ds.repo.diffstatus(
         fr='HEAD' if ds.repo.get_hexsha() else None,
         to=None,
-        paths=paths if paths else None,
+        # recode paths with repo reference for low-level API
+        paths=[repo_path / p.relative_to(ds.pathobj) for p in paths] if paths else None,
         untracked=untracked,
         # TODO think about potential optimizations in case of
         # recursive processing, as this will imply a semi-recursive

--- a/datalad_revolution/tests/test_fileinfo.py
+++ b/datalad_revolution/tests/test_fileinfo.py
@@ -37,7 +37,7 @@ def test_get_content_info(path):
     ds = get_convoluted_situation(path)
     repopath = ds.repo.pathobj
 
-    assert_equal(ds.pathobj, repopath)
+    assert_equal(ds.repo.pathobj, repopath)
     assert_equal(ds.pathobj, ut.Path(path))
 
     # verify general rules on fused info records that are incrementally

--- a/datalad_revolution/tests/test_save.py
+++ b/datalad_revolution/tests/test_save.py
@@ -404,7 +404,8 @@ def test_add_mimetypes(path):
            ('empty', True),
            ('file.txt', False),
            ('file2.txt', True)):
-        p = ds.pathobj / path
+        # low-level API report -> repo path reference, no ds path
+        p = ds.repo.pathobj / path
         assert_in(p, annexinfo)
         if in_annex:
             assert_in('key', annexinfo[p], p)

--- a/datalad_revolution/tests/test_status.py
+++ b/datalad_revolution/tests/test_status.py
@@ -32,6 +32,7 @@ from ..annexrepo import RevolutionAnnexRepo as AnnexRepo
 from .utils import (
     get_deeply_nested_structure,
     has_symlink_capability,
+    assert_repo_status,
 )
 from datalad.api import (
     rev_status as status,
@@ -210,3 +211,15 @@ def test_status(_path, linkpath):
         ds.rev_status(recursive=True, recursion_limit=-1),
         ds.rev_status(recursive=True)
     )
+
+
+# https://github.com/datalad/datalad-revolution/issues/64
+@with_tempfile(mkdir=True)
+def test_subds_status(path):
+    ds = Dataset(path).rev_create()
+    subds = ds.rev_create('subds')
+    subds.rev_create('someotherds')
+    assert_repo_status(subds.path)
+    assert_repo_status(ds.path, modified=['subds'])
+    ds.rev_save('subds')
+    assert_repo_status(ds.path)

--- a/datalad_revolution/tests/test_status.py
+++ b/datalad_revolution/tests/test_status.py
@@ -214,12 +214,20 @@ def test_status(_path, linkpath):
 
 
 # https://github.com/datalad/datalad-revolution/issues/64
+# breaks when the tempdir is a symlink
 @with_tempfile(mkdir=True)
 def test_subds_status(path):
     ds = Dataset(path).rev_create()
     subds = ds.rev_create('subds')
+    assert_repo_status(ds.path)
     subds.rev_create('someotherds')
     assert_repo_status(subds.path)
     assert_repo_status(ds.path, modified=['subds'])
-    ds.rev_save('subds')
-    assert_repo_status(ds.path)
+    assert_result_count(
+        ds.rev_status(path='subds'),
+        1,
+        # must be modified, not added (ds was clean after it was added)
+        state='modified',
+        type='dataset',
+        path=subds.path,
+        refds=ds.path)

--- a/datalad_revolution/tests/test_utils.py
+++ b/datalad_revolution/tests/test_utils.py
@@ -10,6 +10,7 @@ from datalad.tests.utils import (
     with_tempfile,
     eq_,
     on_windows,
+    SkipTest,
 )
 
 from ..dataset import (
@@ -22,6 +23,8 @@ from .. import utils as ut
 
 @with_tempfile(mkdir=True)
 def test_resolve_path(path):
+    if op.realpath(path) != path:
+        raise SkipTest("Test assumptions require non-symlinked parent paths")
     # initially ran into on OSX https://github.com/datalad/datalad/issues/2406
     opath = op.join(path, "origin")
     os.makedirs(opath)

--- a/datalad_revolution/tests/utils.py
+++ b/datalad_revolution/tests/utils.py
@@ -109,7 +109,7 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
             'reason unknown')
     repo = repocls(path, create=True)
     # use create(force) to get an ID and config into the empty repo
-    ds = Dataset(repo.path).rev_create(force=True)
+    ds = Dataset(path).rev_create(force=True)
     # base content
     create_tree(
         ds.path,


### PR DESCRIPTION
Mirror the situation in https://github.com/datalad/datalad/pull/3076 to see where the bugs are.

changes:

- [x] BF use repo path when talking to low-level API
- [x] BF: recode added paths from a low-level repo reference to a high-level dataset reference, before they get emitted by `rev-save()`
- [x] BF: fix inappropriate test assumption
- [x] close #64 `rev-status` too fragile
- [x] anticipate the fix for https://github.com/datalad/datalad/issues/3083 and fix would would fail in the future also
- [x] handling of the detection of a potential conflicting parent dataset content when the target path is symlinked