### PR TITLE
BF: Avoid importing incompatible `pathlib` under PY2

### DIFF
--- a/datalad_revolution/utils.py
+++ b/datalad_revolution/utils.py
@@ -1,13 +1,14 @@
+from six import PY2
 
 # handle this dance once, and import pathlib from here
 # in all other places
-try:
-    from pathlib import (
+if PY2:
+    from pathlib2 import (
         Path,
         PurePosixPath,
     )
-except ImportError:
-    from pathlib2 import (
+else:
+    from pathlib import (
         Path,
         PurePosixPath,
     )


### PR DESCRIPTION
Closes #59