### PR TITLE
Better annex info reporting

### DIFF
--- a/datalad_revolution/annexrepo.py
+++ b/datalad_revolution/annexrepo.py
@@ -122,13 +122,18 @@ class RevolutionAnnexRepo(AnnexRepo, RevolutionGitRepo):
                 paths=paths, ref=ref, **kwargs)
         else:
             info = init
+        # use this funny-looking option with both find and findref
+        # it takes care of git-annex reporting on any known key, regardless
+        # of whether or not it actually (did) exist in the local annex
+        opts = ['--copies', '0']
         if ref:
             cmd = 'findref'
-            opts = [ref]
+            opts.append(ref)
         else:
             cmd = 'find'
             # stringify any pathobjs
-            opts = [str(p) for p in paths] if paths else ['--include', '*']
+            opts.extend([str(p) for p in paths]
+                        if paths else ['--include', '*'])
         for j in self._run_annex_command_json(cmd, opts=opts):
             path = self.pathobj.joinpath(ut.PurePosixPath(j['file']))
             rec = info.get(path, None)

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -46,6 +46,7 @@ from datalad_revolution.revdiff import (
     RevDiff,
     _common_diffstatus_params,
 )
+from datalad.dochelpers import single_or_plural
 
 lgr = logging.getLogger('datalad.revolution.status')
 
@@ -312,16 +313,18 @@ class RevStatus(Interface):
         # fish out sizes of annexed files. those will only be present
         # with --annex ...
         annexed = [
-            int(r['bytesize']) for r in results
-            if r.get('action', None) == 'status'
+            (int(r['bytesize']), r.get('has_content', False))
+            for r in results
+            if r.get('action', None) == 'status' \
             and 'key' in r and 'bytesize' in r]
         if annexed:
             from datalad.ui import ui
             ui.message(
-                "Worktree has {} annex'ed files, "
-                "total size of tracked content: {}".format(
+                "{} annex'd {} ({}/{} present/total size)".format(
                     len(annexed),
-                    bytes2human(sum(annexed))))
+                    single_or_plural('file', 'files', len(annexed)),
+                    bytes2human(sum(a[0] for a in annexed if a[1])),
+                    bytes2human(sum(a[0] for a in annexed))))
 
 
 # TODO move to datalad.utils eventually

--- a/datalad_revolution/tests/test_fileinfo.py
+++ b/datalad_revolution/tests/test_fileinfo.py
@@ -165,7 +165,7 @@ def test_report_absent_keys(path):
     ds = Dataset(path).rev_create()
     # create an annexed file
     testfile = ds.pathobj / 'dummy'
-    testfile.write_text('nothing')
+    testfile.write_text(u'nothing')
     ds.rev_save()
     # present in a full report and in a partial report
     # based on worktree of HEAD ref

--- a/datalad_revolution/tests/test_fileinfo.py
+++ b/datalad_revolution/tests/test_fileinfo.py
@@ -41,7 +41,7 @@ def test_get_content_info(path):
     assert_equal(ds.pathobj, ut.Path(path))
 
     # verify general rules on fused info records that are incrementally
-    # assembled: for git content info, ammended with annex info on 'HEAD'
+    # assembled: for git content info, amended with annex info on 'HEAD'
     # (to get the last commited stage and with it possibly vanished
     # content), and lastly annex info wrt to the present worktree, to
     # also get info on added/staged content
@@ -158,3 +158,45 @@ def test_subds_path(path):
     stat = ds.repo.status(paths=[op.join('sub', 'some.txt')])
     assert_equal(list(stat.keys()), [subds.repo.pathobj])
     assert_equal(stat[subds.repo.pathobj]['state'], 'clean')
+
+
+@with_tempfile
+def test_report_absent_keys(path):
+    ds = Dataset(path).rev_create()
+    # create an annexed file
+    testfile = ds.pathobj / 'dummy'
+    testfile.write_text('nothing')
+    ds.rev_save()
+    # present in a full report and in a partial report
+    # based on worktree of HEAD ref
+    for ai in (
+            ds.repo.get_content_annexinfo(eval_availability=True),
+            ds.repo.get_content_annexinfo(
+                paths=['dummy'],
+                eval_availability=True),
+            ds.repo.get_content_annexinfo(
+                ref='HEAD',
+                eval_availability=True),
+            ds.repo.get_content_annexinfo(
+                ref='HEAD',
+                paths=['dummy'],
+                eval_availability=True)):
+        assert_in(testfile, ai)
+        assert_equal(ai[testfile]['has_content'], True)
+    # drop the key, not available anywhere else
+    ds.drop('dummy', check=False)
+    # does not change a thing, except the key is gone
+    for ai in (
+            ds.repo.get_content_annexinfo(eval_availability=True),
+            ds.repo.get_content_annexinfo(
+                paths=['dummy'],
+                eval_availability=True),
+            ds.repo.get_content_annexinfo(
+                ref='HEAD',
+                eval_availability=True),
+            ds.repo.get_content_annexinfo(
+                ref='HEAD',
+                paths=['dummy'],
+                eval_availability=True)):
+        assert_in(testfile, ai)
+        assert_equal(ai[testfile]['has_content'], False)


### PR DESCRIPTION
- [x] more useful report
  ```
  % datalad rev-status -r --annex all
  619 annex'd files (38.0 B/107.7 MB present/total size)
  ```
- [x] more robust reporting when keys are missing locally (fixes #68)