### PR TITLE
ENH(BK): relative imports start again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,11 @@ script:
       --with-cov --cover-package datalad_revolution
       --logging-level=INFO
       $TESTS_TO_PERFORM
+  # Imports should be relative
+  - if grep -r -e '\(from\|import\)\s\s*datalad_revolution' datalad_revolution; then
+      echo Convert absolute imports to relative;
+      exit 1;
+    fi
   #- if [ ! "${DATALAD_LOG_LEVEL:-}" = 2 ]; then
   #      PYTHONPATH=$PWD $NOSE_WRAPPER make -C docs html doctest;
   #  fi

--- a/datalad_revolution/revdiff.py
+++ b/datalad_revolution/revdiff.py
@@ -41,7 +41,7 @@ from .dataset import (
     path_under_dataset,
     get_dataset_root,
 )
-import datalad_revolution.utils as ut
+from . import utils as ut
 
 from datalad.support.constraints import (
     EnsureNone,

--- a/datalad_revolution/revstatus.py
+++ b/datalad_revolution/revstatus.py
@@ -42,7 +42,7 @@ from .dataset import (
 )
 from . import utils as ut
 
-from datalad_revolution.revdiff import (
+from .revdiff import (
     RevDiff,
     _common_diffstatus_params,
 )


### PR DESCRIPTION
Originally RFed in #60 

- [ ] Travis - fail if any absolute import left
- [x] Fix absolute imports -- will come after first commit is shown to fail the travis