### PR TITLE
Next-level metadata

### DIFF
--- a/datalad_revolution/metadata/__init__.py
+++ b/datalad_revolution/metadata/__init__.py
@@ -107,19 +107,6 @@ def get_refcommit(ds):
         count += 1
 
 
-def get_refcommit_from_metadata(md):
-    """Given a metadata record will report 'refcommit' of the dataset.
-
-    Expected is a full metadata records (all extractors). Returns None if
-    there is none.
-    """
-    dcmd = md.get('datalad_core', {})
-    docs = dcmd['@graph'] if '@graph' in dcmd else [dcmd]
-    for doc in docs:
-        if doc.get('@type', None) == 'Dataset' and '@id' in doc:
-            return doc['@id']
-
-
 class ReadOnlyDict(Mapping):
     # Taken from https://github.com/slezica/python-frozendict
     # License: MIT

--- a/datalad_revolution/metadata/__init__.py
+++ b/datalad_revolution/metadata/__init__.py
@@ -1,4 +1,7 @@
 
+from collections import (
+    Mapping,
+)
 
 from six import iteritems
 from datalad.utils import (
@@ -14,6 +17,17 @@ exclude_from_metadata = ('.datalad', '.git', '.gitmodules', '.gitattributes')
 
 # TODO filepath_info is obsolete
 location_keys = ('dataset_info', 'content_info', 'filepath_info')
+
+
+# this is the default context, but any node document can define
+# something more suitable
+default_context = {
+    # schema.org definitions by default
+    "@vocab": "http://schema.org/",
+    # resolve non-compact/absolute identifiers to the DataLad
+    # resolver
+    "@base": "http://dx.datalad.org/",
+}
 
 
 def get_metadata_type(ds):
@@ -91,3 +105,63 @@ def get_refcommit(ds):
             return ds.repo.get_hexsha(cur)
         # next pair
         count += 1
+
+
+class ReadOnlyDict(Mapping):
+    # Taken from https://github.com/slezica/python-frozendict
+    # License: MIT
+
+    # XXX entire class is untested
+
+    """
+    An immutable wrapper around dictionaries that implements the complete
+    :py:class:`collections.Mapping` interface. It can be used as a drop-in
+    replacement for dictionaries where immutability is desired.
+    """
+    dict_cls = dict
+
+    def __init__(self, *args, **kwargs):
+        self._dict = self.dict_cls(*args, **kwargs)
+        self._hash = None
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __contains__(self, key):
+        return key in self._dict
+
+    def copy(self, **add_or_replace):
+        return self.__class__(self, **add_or_replace)
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def __len__(self):
+        return len(self._dict)
+
+    def __repr__(self):
+        return '<%s %r>' % (self.__class__.__name__, self._dict)
+
+    def __hash__(self):
+        if self._hash is None:
+            h = 0
+            for key, value in iteritems(self._dict):
+                h ^= hash((key, _val2hashable(value)))
+            self._hash = h
+        return self._hash
+
+
+def _val2hashable(val):
+    """Small helper to convert incoming mutables to something hashable
+
+    The goal is to be able to put the return value into a set, while
+    avoiding conversions that would result in a change of representation
+    in a subsequent JSON string.
+    """
+    # XXX special cases are untested, need more convoluted metadata
+    if isinstance(val, dict):
+        return ReadOnlyDict(val)
+    elif isinstance(val, list):
+        return tuple(map(_val2hashable, val))
+    else:
+        return val

--- a/datalad_revolution/metadata/__init__.py
+++ b/datalad_revolution/metadata/__init__.py
@@ -174,7 +174,9 @@ def collect_jsonld_metadata(dspath, res, nodes_by_context, contexts):
     Parameters
     ----------
     dspath : str or Path
-      Native absolute path of the dataset on which the results are.
+      Native absolute path of the dataset that shall be used to determine
+      the relative path (name) of a file-result. This would typically be
+      the path to the dataset that contains the file.
     res : dict
       Result dictionary as produced by `extract_metadata()` or
       `query_metadata()`.

--- a/datalad_revolution/metadata/__init__.py
+++ b/datalad_revolution/metadata/__init__.py
@@ -107,6 +107,19 @@ def get_refcommit(ds):
         count += 1
 
 
+def get_refcommit_from_metadata(md):
+    """Given a metadata record will report 'refcommit' of the dataset.
+
+    Expected is a full metadata records (all extractors). Returns None if
+    there is none.
+    """
+    dcmd = md.get('datalad_core', {})
+    docs = dcmd['@graph'] if '@graph' in dcmd else [dcmd]
+    for doc in docs:
+        if doc.get('@type', None) == 'Dataset' and 'refcommit' in doc:
+            return doc['refcommit']
+
+
 class ReadOnlyDict(Mapping):
     # Taken from https://github.com/slezica/python-frozendict
     # License: MIT

--- a/datalad_revolution/metadata/__init__.py
+++ b/datalad_revolution/metadata/__init__.py
@@ -116,8 +116,8 @@ def get_refcommit_from_metadata(md):
     dcmd = md.get('datalad_core', {})
     docs = dcmd['@graph'] if '@graph' in dcmd else [dcmd]
     for doc in docs:
-        if doc.get('@type', None) == 'Dataset' and 'refcommit' in doc:
-            return doc['refcommit']
+        if doc.get('@type', None) == 'Dataset' and '@id' in doc:
+            return doc['@id']
 
 
 class ReadOnlyDict(Mapping):

--- a/datalad_revolution/metadata/extractors/annex.py
+++ b/datalad_revolution/metadata/extractors/annex.py
@@ -32,7 +32,7 @@ from datalad.support.annexrepo import AnnexRepo
 
 
 class AnnexMetadataExtractor(MetadataExtractor):
-    def __call__(self, dataset, process_type, status):
+    def __call__(self, dataset, refcommit, process_type, status):
         # shortcut
         ds = dataset
 

--- a/datalad_revolution/metadata/extractors/base.py
+++ b/datalad_revolution/metadata/extractors/base.py
@@ -13,7 +13,7 @@ class MetadataExtractor(object):
     # ATM this doesn't do anything, but inheritance from this class enables
     # detection of new-style extractor API
 
-    def __call__(self, dataset, process_type, status):
+    def __call__(self, dataset, refcommit, process_type, status):
         """Run metadata extraction
 
         Any implementation gets a comprehensive description of a dataset
@@ -25,6 +25,10 @@ class MetadataExtractor(object):
         ----------
         dataset : Dataset
           Dataset instance to extract metadata from.
+        refcommit : str
+          SHA of the commit that was determined to be the last metadata-relevant
+          change in the dataset. Can be used for identification purposed, such
+          '@id' properties for JSON-LD documents on the dataset.
         process_type : {'all', 'dataset', 'content'}
           Type of metadata to extract.
         status : list

--- a/datalad_revolution/metadata/extractors/core.py
+++ b/datalad_revolution/metadata/extractors/core.py
@@ -99,10 +99,12 @@ class DataladCoreExtractor(MetadataExtractor):
         commitinfo = _get_commit_info(ds, status)
         contributor_ids = []
         for contributor in commitinfo.pop('contributors', []):
-            contributor_id = '{} <{}>'.format(*contributor)
+            # use RFC822 inspired style as ID
+            contributor_id = '{}<{}>'.format(
+                contributor[0].replace(' ', '_'),
+                contributor[1])
             yield {
-                # use RFC822-style address as ID
-                '@id': '{} <{}>'.format(*contributor),
+                '@id': contributor_id,
                 # we cannot distinguish real people from machine-committers
                 '@type': 'agent',
                 'name': contributor[0],

--- a/datalad_revolution/metadata/extractors/core.py
+++ b/datalad_revolution/metadata/extractors/core.py
@@ -112,14 +112,18 @@ class DataladCoreExtractor(MetadataExtractor):
             }
             contributor_ids.append(contributor_id)
         meta = {
-            # the desired ID
-            '@id': ds.id,
+            # the uniquest ID for this metadata record is the refcommit SHA
+            '@id': commitinfo['refcommit'],
+            # the dataset UUID is the main identifier
+            'identifier': ds.id,
             '@type': 'Dataset',
         }
+        # refcommit is already in
+        commitinfo.pop('refcommit', None)
+        meta.update(commitinfo)
         if contributor_ids:
             c = [{'@id': i} for i in contributor_ids]
             meta['hasContributor'] = c[0] if len(c) == 1 else c
-        meta.update(commitinfo)
         parts = [{
             '@type': 'Dataset' if part['type'] == 'dataset'
             # schema.org doesn't have anything good for a symlink, as it could

--- a/datalad_revolution/metadata/extractors/custom.py
+++ b/datalad_revolution/metadata/extractors/custom.py
@@ -52,7 +52,7 @@ class CustomMetadataExtractor(MetadataExtractor):
                 if op.lexists(f):
                     yield dict(path=f)
 
-    def __call__(self, dataset, process_type, status):
+    def __call__(self, dataset, refcommit, process_type, status):
         # shortcut
         ds = dataset
 

--- a/datalad_revolution/metadata/extractors/tests/test_base.py
+++ b/datalad_revolution/metadata/extractors/tests/test_base.py
@@ -147,7 +147,8 @@ def test_report(path, orig):
         res[0]['metadata']['datalad_core']
     )
     assert_in(
-        {'@type': 'Dataset', '@id': subds.id, 'name': 'sub'},
+        {'@type': 'Dataset', '@id': subds.repo.get_hexsha(),
+         'identifier': subds.id, 'name': 'sub'},
         core_dsmeta['hasPart']
     )
     # has not seen the content

--- a/datalad_revolution/metadata/query.py
+++ b/datalad_revolution/metadata/query.py
@@ -398,6 +398,7 @@ class QueryMetadata(Interface):
                 type='dataset',
                 path=ds.path,
                 metadata=format_jsonld_metadata(nodes_by_context),
+                refcommit=agginfos[ds.pathobj]['refcommit'],
                 **res_kwargs)
 
     @staticmethod

--- a/datalad_revolution/metadata/query.py
+++ b/datalad_revolution/metadata/query.py
@@ -256,7 +256,7 @@ class QueryMetadata(Interface):
             reporton='all',
             recursive=False):
         # prep results
-        res_kwargs = dict(action='metadata', logger=lgr)
+        res_kwargs = dict(action='query_metadata', logger=lgr)
         ds = require_dataset(
             dataset=dataset,
             check_installed=True,
@@ -402,7 +402,7 @@ class QueryMetadata(Interface):
 
     @staticmethod
     def custom_result_renderer(res, **kwargs):
-        if res['status'] != 'ok' or not res.get('action', None) == 'metadata':
+        if res['status'] != 'ok' or not res.get('action', None) == 'query_metadata':
             # logging complained about this already
             return
         # list the path, available metadata keys, and tags

--- a/datalad_revolution/metadata/revaggregate.py
+++ b/datalad_revolution/metadata/revaggregate.py
@@ -52,6 +52,7 @@ from . import (
     location_keys,
     ReadOnlyDict,
     _val2hashable,
+    get_refcommit_from_metadata,
 )
 
 from .query import (
@@ -1003,8 +1004,7 @@ def _extract_metadata(fromds, tods, exinfo):
 
     # place recorded refcommit in info dict to facilitate subsequent
     # change detection
-    refcommit = \
-        meta['dataset'].get('datalad_core', {}).get('refcommit', None)
+    refcommit = get_refcommit_from_metadata(meta['dataset'])
     if refcommit:
         lgr.debug('Update %s refcommit to %s', fromds, refcommit)
         info['refcommit'] = refcommit

--- a/datalad_revolution/metadata/revaggregate.py
+++ b/datalad_revolution/metadata/revaggregate.py
@@ -52,7 +52,6 @@ from . import (
     location_keys,
     ReadOnlyDict,
     _val2hashable,
-    get_refcommit_from_metadata,
 )
 
 from .query import (
@@ -950,6 +949,17 @@ def _extract_metadata(fromds, tods, exinfo):
                 )
                 yield res
                 continue
+            refcommit = res.get('refcommit', None)
+            if refcommit:
+                lgr.debug('Update %s refcommit to %s', fromds, refcommit)
+                # place recorded refcommit in info dict to facilitate
+                # subsequent change detection
+                info['refcommit'] = refcommit
+            else:
+                lgr.debug(
+                    'Could not determine a reference commit for the metadata '
+                    'extracted from %s', fromds)
+
             meta['dataset'] = res['metadata']
         elif restype == 'file':
             fmeta = res['metadata']
@@ -1001,17 +1011,6 @@ def _extract_metadata(fromds, tods, exinfo):
             logger=lgr,
         )
         return
-
-    # place recorded refcommit in info dict to facilitate subsequent
-    # change detection
-    refcommit = get_refcommit_from_metadata(meta['dataset'])
-    if refcommit:
-        lgr.debug('Update %s refcommit to %s', fromds, refcommit)
-        info['refcommit'] = refcommit
-    else:
-        lgr.debug(
-            'Could not determine a reference commit for the metadata '
-            'extracted from %s', fromds)
 
     # create a tempdir for this dataset under .git/tmp
     tmp_basedir = _get_aggtmp_basedir(tods, mkdir=True)

--- a/datalad_revolution/metadata/revextract.py
+++ b/datalad_revolution/metadata/revextract.py
@@ -41,6 +41,7 @@ from datalad.support.constraints import (
     EnsureBool,
 )
 from . import (
+    get_refcommit,
     exclude_from_metadata,
     get_metadata_type,
     default_context,
@@ -305,12 +306,32 @@ class RevExtractMetadata(Interface):
                     {k: v for k, v in iteritems(r)
                      if (k not in ('refds', 'parentds', 'action', 'status')
                          and not k.startswith('prev_'))})
+
+            # determine the commit that we are describing
+            refcommit = get_refcommit(ds)
+            if refcommit is None or not len(status):
+                # this seems extreme, but without a single commit there is
+                # nothing we can have, or describe -> blow
+                yield dict(
+                    res_props,
+                    status='error',
+                    message=\
+                    'No metadata-relevant repository content found. ' \
+                    'Cannot determine reference commit for metadata ID',
+                    type='dataset',
+                    path=ds.path,
+                )
+                return
+            # stamp every result
+            res_props['refcommit'] = refcommit
         else:
             # no dataset at hand, take path arg at face value and hope
             # for the best
             # TODO we have to resolve the given path to make it match what
             # status is giving (abspath with ds (not repo) anchor)
             status = [dict(path=p, type='file') for p in assure_list(path)]
+            # just for compatibility, mandatory argument list below
+            refcommit = None
 
         if ds.is_installed():
             # check availability requirements and obtain data as needed
@@ -336,11 +357,13 @@ class RevExtractMetadata(Interface):
                         # online complain when something goes wrong
                         yield r
 
+
         contexts = {}
         nodes_by_context = {}
         try:
             for res in _proc(
                     ds,
+                    refcommit,
                     sources,
                     status,
                     extractors,
@@ -437,7 +460,7 @@ class RevExtractMetadata(Interface):
                  ','.join(assure_list(meta['tag'])))))
 
 
-def _proc(ds, sources, status, extractors, process_type):
+def _proc(ds, refcommit, sources, status, extractors, process_type):
     dsmeta = dict()
     contentmeta = {}
 
@@ -464,6 +487,7 @@ def _proc(ds, sources, status, extractors, process_type):
                 extractor['class'],
                 msrc,
                 ds,
+                refcommit,
                 status,
                 extractor['process_type']):
             # always have a path, use any absolute path coming in,
@@ -553,7 +577,7 @@ def _proc(ds, sources, status, extractors, process_type):
         yield res
 
 
-def _run_extractor(extractor_cls, name, ds, status, process_type):
+def _run_extractor(extractor_cls, name, ds, refcommit, status, process_type):
     """Helper to control extractor using the right API
 
     Central switch to deal with alternative/future APIs is inside
@@ -565,6 +589,7 @@ def _run_extractor(extractor_cls, name, ds, status, process_type):
             extractor = extractor_cls()
             for r in extractor(
                     dataset=ds,
+                    refcommit=refcommit,
                     status=status,
                     process_type=process_type):
                 yield r

--- a/datalad_revolution/metadata/revextract.py
+++ b/datalad_revolution/metadata/revextract.py
@@ -145,7 +145,7 @@ class RevExtractMetadata(Interface):
             properties that are stored under the name of the associated
             extractor; 'jsonld' composes a JSON-LD graph document, while
             stripping any information that does not appear to be properly
-            typed linked data.""",
+            typed linked data (extractor reports no '@context' field).""",
             constraints=EnsureChoice(
                 'native', 'jsonld')),
     )

--- a/datalad_revolution/metadata/revextract.py
+++ b/datalad_revolution/metadata/revextract.py
@@ -365,7 +365,10 @@ class RevExtractMetadata(Interface):
                             contexts,
                             defaults={
                                 '@id': fid,
-                                '@type': "DigitalDocument",
+                                # do not have a @type default here, it would
+                                # duplicate across all extractor records
+                                # let the core extractor deal with this
+                                #'@type': "DigitalDocument",
                                 # maybe we need something more fitting than
                                 # name
                                 'name': Path(res['path']).relative_to(
@@ -730,6 +733,10 @@ def _native_metadata_to_graph_nodes(
             # not a multi-document graph, remove context and treat as
             # a single-node graph
             report.pop('@context', None)
+            if not report:
+                # there is no other information, and we have the context
+                # covered already
+                continue
             if defaults is not None:
                 # this will typically happen for content/file reports
                 report = dict(
@@ -753,7 +760,7 @@ def _nodes_by_context_to_jsonld(nbc):
         if k == ro_default_context:
             # if the context matches the default, extend the top-level graph
             graph.extend(v)
-        else:
+        elif v:
             # document with a different context: add as a sub graph
             graph.append({
                 '@context': dict(k),

--- a/datalad_revolution/metadata/revextract.py
+++ b/datalad_revolution/metadata/revextract.py
@@ -398,8 +398,6 @@ class RevExtractMetadata(Interface):
                                     ds.pathobj).as_posix(),
                             },
                         )
-                        # TODO extend 'hasPart' of the mother dataset with each
-                        # file content node ID
         finally:
             # extractors can come from any source with no guarantee for
             # proper implementation. Let's make sure that we bring the

--- a/datalad_revolution/metadata/revextract.py
+++ b/datalad_revolution/metadata/revextract.py
@@ -387,6 +387,7 @@ class RevExtractMetadata(Interface):
             yield dict(
                 status='ok',
                 type='dataset',
+                path=ds.path,
                 metadata=format_jsonld_metadata(nodes_by_context),
                 **res_props)
 

--- a/datalad_revolution/metadata/tests/__init__.py
+++ b/datalad_revolution/metadata/tests/__init__.py
@@ -23,3 +23,14 @@ def make_ds_hierarchy_with_metadata(path):
     (subds.pathobj / 'real').write_text(text_type('real'))
     ds.rev_save(recursive=True)
     return ds, subds
+
+
+def _get_dsid_from_core_metadata(md):
+    return _get_dsmeta_from_core_metadata(md)['@id']
+
+
+def _get_dsmeta_from_core_metadata(md):
+    docs = md['@graph'] if '@graph' in md else [md]
+    for doc in docs:
+        if doc.get('@type', None) == 'Dataset':
+            return doc

--- a/datalad_revolution/metadata/tests/test_aggregate.py
+++ b/datalad_revolution/metadata/tests/test_aggregate.py
@@ -527,7 +527,7 @@ def _kill_time(iter):
     for r in iter:
         # TODO why is it two of them?
         r.pop('refcommit', None)
-        for k in ('refcommit', 'dateModified', 'version'):
+        for k in ('@id', 'dateModified', 'version'):
             if '@graph' in r['metadata']['datalad_core']:
                 for doc in r['metadata']['datalad_core']['@graph']:
                     doc.pop(k, None)

--- a/datalad_revolution/metadata/tests/test_aggregate.py
+++ b/datalad_revolution/metadata/tests/test_aggregate.py
@@ -531,6 +531,10 @@ def _kill_time(iter):
             if '@graph' in r['metadata']['datalad_core']:
                 for doc in r['metadata']['datalad_core']['@graph']:
                     doc.pop(k, None)
+                    if 'hasPart' in doc:
+                        # for shasum-based IDs
+                        for i in doc['hasPart']:
+                            i.pop(k, None)
             else:
                 r.pop(k, None)
         m.append(r)

--- a/datalad_revolution/metadata/tests/test_aggregate.py
+++ b/datalad_revolution/metadata/tests/test_aggregate.py
@@ -45,6 +45,7 @@ from datalad.tests.utils import (
 )
 from . import (
     make_ds_hierarchy_with_metadata,
+    _get_dsid_from_core_metadata,
 )
 
 
@@ -141,9 +142,8 @@ def _compare_metadata_helper(origres, compds):
         cres = cres[0]
         assert_dict_equal(ores['metadata'], cres['metadata'])
         if ores['type'] == 'dataset':
-            for i in ('@id', ):
-                eq_(ores['metadata']['datalad_core'][i],
-                    cres['metadata']['datalad_core'][i])
+            eq_(_get_dsid_from_core_metadata(ores['metadata']['datalad_core']),
+                _get_dsid_from_core_metadata(cres['metadata']['datalad_core']))
 
 
 @slow  # ~16s
@@ -194,8 +194,9 @@ def test_aggregation(path):
     # three different IDs
     eq_(
         3,
-        len(set([s['metadata']['datalad_core']['@id']
-                for s in origres if s['type'] == 'dataset'])))
+        len(set([_get_dsid_from_core_metadata(s['metadata']['datalad_core'])
+                 for s in origres
+                 if s['type'] == 'dataset'])))
     # and we know about all three datasets
     for name in ('MOTHER_äöü東', 'child_äöü東', 'grandchild_äöü東'):
         assert_true(
@@ -527,7 +528,11 @@ def _kill_time(iter):
         # TODO why is it two of them?
         r.pop('refcommit', None)
         for k in ('refcommit', 'dateModified', 'version'):
-            r['metadata']['datalad_core'].pop(k, None)
+            if '@graph' in r['metadata']['datalad_core']:
+                for doc in r['metadata']['datalad_core']['@graph']:
+                    doc.pop(k, None)
+            else:
+                r.pop(k, None)
         m.append(r)
     return m
 
@@ -729,36 +734,34 @@ def test_unique_values(path):
     assert_result_count(res, 1)
     ucm = res[0]['metadata']['datalad_unique_content_properties']
     eq_(
-        ucm,
+        ucm['custom'],
         {
-            "custom": {
-                # complex types do not get shmooshed together
-                "complextype": [
-                    {
-                        "age": "young",
-                        "entity": {
-                            "properties": "here",
-                            "some": "many"
-                        },
-                        "numbers": [
-                            3,
-                            2,
-                            1,
-                            0
-                        ]
+            # complex types do not get shmooshed together
+            "complextype": [
+                {
+                    "age": "young",
+                    "entity": {
+                        "properties": "here",
+                        "some": "many"
                     },
-                    {
-                        "entity": {
-                            "properties": "here",
-                            "some": "few"
-                        }
+                    "numbers": [
+                        3,
+                        2,
+                        1,
+                        0
+                    ]
+                },
+                {
+                    "entity": {
+                        "properties": "here",
+                        "some": "few"
                     }
-                ],
-                # simple type get unique'd as expected
-                "something": [
-                    "stupid"
-                ]
-            }
+                }
+            ],
+            # simple type get unique'd as expected
+            "something": [
+                "stupid"
+            ]
         })
 
 

--- a/datalad_revolution/metadata/tests/test_query.py
+++ b/datalad_revolution/metadata/tests/test_query.py
@@ -1,6 +1,7 @@
 import os.path as op
 from six import (
     text_type,
+    iteritems,
 )
 
 from datalad.support.gitrepo import GitRepo
@@ -145,3 +146,13 @@ def test_query(path, orig):
     assert_result_count(res, 2)
     assert_result_count(res, 1, id=origds.id)
     assert_result_count(res, 1, id=subds.id)
+
+    extract_res = origds.rev_extract_metadata(format='jsonld')
+    assert_result_count(extract_res, 1)
+    query_res = ds.query_metadata(reporton='jsonld')
+    assert_result_count(query_res, 1)
+    strip = ('path', 'action', 'refds')
+    eq_(
+        {k: v for k, v in iteritems(extract_res[0]) if k not in strip},
+        {k: v for k, v in iteritems(query_res[0]) if k not in strip},
+    )


### PR DESCRIPTION
Prompted by a few realizations I had while working on #118

- [x] any extractor can now report metadata records on multiple entities (not just datasets and files). It can simply report metadata using JSON-LD graphs documents (`{"@content": {}, "@graph": []}`) with as many nodes as desired, using whatever `@type` to identifier the nature of the described entity
- [x] rev-extract-metadata can now report a single JSON-LD object with ALL linked metadata on anything in a dataset
- [x] there is no longer a "refcommit" field in the core metadata. This is used for `@id` now. The dataset UUID is now in `identifier`
- [x] `--reporton jsonld` for `query-metadata`
- [x] Consider RF to determine the refcommit upfront and provide extractors this value as a readily usable ID. Without it, we are implicitly limitation JSON-LD reports to a single dataset-type document (to assign an ID to). Hence any extractor could not talk about two datasets, one of which is just described in order to document a particular relationship. This would break the promise of "any output works".