### PR TITLE
Add rev_save as shim for core's save

### DIFF
--- a/datalad_revolution/__init__.py
+++ b/datalad_revolution/__init__.py
@@ -12,6 +12,12 @@ command_suite = (
     "DataLad revolutionary command suite",
     [
         (
+            'datalad_revolution.revsave',
+            'RevSave',
+            'rev-save',
+            'rev_save'
+        ),
+        (
             'datalad_revolution.revcreate',
             'RevCreate',
             'rev-create',

--- a/datalad_revolution/revsave.py
+++ b/datalad_revolution/revsave.py
@@ -10,4 +10,43 @@ if '_generate_extension_api' not in _tb:  # pragma: no cover
         'The `RevSave` class can be imported with: '
         '`from datalad.core.local.save import Save as RevSave`')
 
-from datalad.core.local.save import Save as RevSave
+from datalad.interface.base import (
+    build_doc,
+)
+from datalad.interface.utils import eval_results
+from .dataset import (
+    rev_datasetmethod,
+)
+
+from datalad.core.local.save import Save
+
+
+@build_doc
+class RevSave(Save):
+
+    @staticmethod
+    @rev_datasetmethod(name='rev_save')
+    @eval_results
+    def __call__(path=None,
+                 message=None,
+                 dataset=None,
+                 version_tag=None,
+                 recursive=False,
+                 recursion_limit=None,
+                 updated=False,
+                 message_file=None,
+                 to_git=None):
+        for r in Save.__call__(path=path,
+                               message=message,
+                               dataset=dataset,
+                               version_tag=version_tag,
+                               recursive=recursive,
+                               recursion_limit=recursion_limit,
+                               updated=updated,
+                               message_file=message_file,
+                               to_git=to_git,
+                               result_renderer=None,
+                               result_xfm=None,
+                               on_failure="ignore",
+                               return_type='generator'):
+            yield r


### PR DESCRIPTION
datalad/datalad#3408 replaces core's save with rev_save.  Add back a
compatibility alias, like we already do for other commands.