### PR TITLE
RF: Add rev_run as shim for core's run

### DIFF
--- a/datalad_revolution/__init__.py
+++ b/datalad_revolution/__init__.py
@@ -29,6 +29,12 @@ command_suite = (
             'rev-diff',
             'rev_diff'
         ),
+        (
+            'datalad_revolution.revrun',
+            'RevRun',
+            'rev-run',
+            'rev_run'
+        ),
     ]
 )
 

--- a/datalad_revolution/revrun.py
+++ b/datalad_revolution/revrun.py
@@ -1,0 +1,50 @@
+import logging
+
+import traceback
+lgr = logging.getLogger('datalad.revolution.run')
+
+_tb = [t[2] for t in traceback.extract_stack()]
+if '_generate_extension_api' not in _tb:  # pragma: no cover
+    lgr.warn(
+        "The module 'datalad_revolution.revrun' is deprecated. "
+        'The `RevRun` class can be imported with: '
+        '`from datalad.interface.run import Run as RevRun`')
+
+from datalad.interface.base import (
+    build_doc,
+)
+from datalad.interface.utils import eval_results
+from .dataset import (
+    rev_datasetmethod,
+)
+
+from datalad.interface.run import Run
+
+
+@build_doc
+class RevRun(Run):
+
+    @staticmethod
+    @rev_datasetmethod(name='rev_run')
+    @eval_results
+    def __call__(cmd=None,
+                 dataset=None,
+                 inputs=None,
+                 outputs=None,
+                 expand=None,
+                 explicit=False,
+                 message=None,
+                 sidecar=None):
+        for r in Run.__call__(cmd=cmd,
+                              dataset=dataset,
+                              inputs=inputs,
+                              outputs=outputs,
+                              expand=expand,
+                              explicit=explicit,
+                              message=message,
+                              sidecar=sidecar,
+                              result_renderer=None,
+                              result_xfm=None,
+                              on_failure="ignore",
+                              return_type='generator'):
+            yield r


### PR DESCRIPTION
core's run has been the same as rev_run since eba3ccfd6 (BF: run: Save
results with rev-save, 2019-03-18).  As of datalad/datalad#3409, core
is dropping its rev_run shim, so add it here.